### PR TITLE
Reset marker should publish initialized quaternion

### DIFF
--- a/src/rviz_visual_tools.cpp
+++ b/src/rviz_visual_tools.cpp
@@ -95,6 +95,7 @@ bool RvizVisualTools::loadRvizMarkers()
   reset_marker_.header.stamp = ros::Time();
   reset_marker_.ns = "deleteAllMarkers";  // helps during debugging
   reset_marker_.action = 3;               // TODO(davetcoleman): In ROS-J set to visualization_msgs::Marker::DELETEALL;
+  reset_marker_.pose.orientation.w = 1;
 
   // Load arrow ----------------------------------------------------
 


### PR DESCRIPTION
Closely related to https://github.com/ros-visualization/rviz/pull/1179
Not sure if there are other places where invalid quaternions still stand.
Cannot hurt!