### PR TITLE
link qt code into the _gui library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ set(SOURCE_FILES
 )
 
 # Rviz GUI library
-add_library(${PROJECT_NAME}_gui ${SOURCE_FILES} src/remote_control.cpp)
+add_library(${PROJECT_NAME}_gui ${MOC_FILES} ${SOURCE_FILES} src/remote_control.cpp)
 target_link_libraries(${PROJECT_NAME}_gui ${rviz_DEFAULT_PLUGIN_LIBRARIES} ${QT_LIBRARIES} ${catkin_LIBRARIES})
 
 # Remote control library


### PR DESCRIPTION
I have no idea why this ever worked, but it broke on my system (non-ubuntu) just now.
Apparently you forgot to link the autogenerated qt code into the library that provides the classes.

Fixes \#71.