### PR TITLE
no ros::spinOnce()

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,5 +4,5 @@ API changes in Rviz Visual Tools releases
 
 ## ROS Melodic
 
-- RvizVisualTools::publishMarkers called ros::spinOnce() in previous versions. This was usualy a bug as it might lead to running ros callback functions in unrelated threads (eg your UI thread). In the unlikely case that your programm relied on publishMarkers calling ros::spinOnce() you will now have to add either a ros::spinOnce after your call to publishMarkers or simply add a ros::AsyncSpinner. See http://wiki.ros.org/roscpp/Overview/Callbacks%20and%20Spinning for more details.
+- RvizVisualTools::publishMarkers called ros::spinOnce() in previous versions. This was usually a bug as it might lead to running ROS callback functions in unrelated threads (e.g. your UI thread). In the unlikely case that your program relied on publishMarkers calling ros::spinOnce() you will now have to add either a ros::spinOnce after your call to publishMarkers or simply add a ros::AsyncSpinner. See http://wiki.ros.org/roscpp/Overview/Callbacks%20and%20Spinning for more details.
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,8 @@
+# Migration Notes
+
+API changes in Rviz Visual Tools releases
+
+## ROS Melodic
+
+- RvizVisualTools::publishMarkers called ros::spinOnce() in previous versions. This was usualy a bug as it might lead to running ros callback functions in unrelated threads (eg your UI thread). In the unlikely case that your programm relied on publishMarkers calling ros::spinOnce() you will now have to add either a ros::spinOnce after your call to publishMarkers or simply add a ros::AsyncSpinner. See http://wiki.ros.org/roscpp/Overview/Callbacks%20and%20Spinning for more details.
+

--- a/src/rviz_visual_tools.cpp
+++ b/src/rviz_visual_tools.cpp
@@ -928,7 +928,6 @@ bool RvizVisualTools::publishMarkers(visualization_msgs::MarkerArray& markers)
 
   // Publish
   pub_rviz_markers_.publish(markers);
-  ros::spinOnce();
   return true;
 }
 


### PR DESCRIPTION
calling ros::spinOnce() in random places ( ;) ) messes up threading. This causes updates to PlanningSceneMonitor and joint state to be handled in our gui thread as opposed to the async spinner thread where we intended them to be handled.