### PR TITLE
Improve package with catkin_lint

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,25 +14,25 @@ add_definitions(-W -Wall -Wextra
 
 find_package(catkin REQUIRED COMPONENTS
   eigen_conversions
+  eigen_stl_containers
   geometry_msgs
   graph_msgs
   roscpp
+  roslint
   rostest
+  rviz
+  sensor_msgs
   std_msgs
   tf_conversions
   trajectory_msgs
   visualization_msgs
-  roslint
-  eigen_stl_containers
-  rviz
-  sensor_msgs
 )
 
 find_package(Eigen3 REQUIRED)
 find_package(Boost REQUIRED thread system)
 
 # Qt 4 or 5
-if(rviz_QT_VERSION VERSION_LESS "5")
+if("${rviz_QT_VERSION}" VERSION_LESS "5")
   find_package(Qt4 ${rviz_QT_VERSION} REQUIRED QtCore QtGui)
   include(${QT_USE_FILE})
   macro(qt_wrap_ui)
@@ -60,13 +60,13 @@ catkin_package(
   CATKIN_DEPENDS
     eigen_conversions
     geometry_msgs
-    visualization_msgs
     graph_msgs
+    roscpp
+    sensor_msgs
     std_msgs
     tf_conversions
     trajectory_msgs
-    sensor_msgs
-    roscpp
+    visualization_msgs
   INCLUDE_DIRS
     include
 )
@@ -150,8 +150,8 @@ install(
   TARGETS
     ${PROJECT_NAME}
     ${PROJECT_NAME}_gui
-    ${PROJECT_NAME}_remote_control
     ${PROJECT_NAME}_imarker_simple
+    ${PROJECT_NAME}_remote_control
   LIBRARY DESTINATION
     ${CATKIN_PACKAGE_LIB_DESTINATION}
 )


### PR DESCRIPTION
# Before
```
$ catkin_lint -W3 .
rviz_visual_tools: notice: target name 'imarker_simple_demo' might not be sufficiently unique
rviz_visual_tools: CMakeLists.txt(15): notice: list COMPONENTS should be sorted
rviz_visual_tools: CMakeLists.txt(35): notice: operands for operator VERSION_LESS should be quoted strings
rviz_visual_tools: CMakeLists.txt(54): notice: list CATKIN_DEPENDS should be sorted
rviz_visual_tools: CMakeLists.txt(86): notice: list of source files should be sorted
rviz_visual_tools: CMakeLists.txt(149): notice: list TARGETS should be sorted
rviz_visual_tools: CMakeLists.txt(173): notice: list TARGETS should be sorted
catkin_lint: checked 1 packages and found 7 problems
```

# After
```
$ catkin_lint -W3 .
rviz_visual_tools: notice: target name 'imarker_simple_demo' might not be sufficiently unique
rviz_visual_tools: CMakeLists.txt(86): notice: list of source files should be sorted
rviz_visual_tools: CMakeLists.txt(173): notice: list TARGETS should be sorted
catkin_lint: checked 1 packages and found 3 problems
```