### PR TITLE
Fix some catkin_lint warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,12 +119,22 @@ target_link_libraries(${PROJECT_NAME}_imarker_simple
 add_executable(${PROJECT_NAME}_demo src/${PROJECT_NAME}_demo.cpp)
 target_link_libraries(${PROJECT_NAME}_demo
   ${catkin_LIBRARIES} ${PROJECT_NAME}
-  )
+)
+set_target_properties(${PROJECT_NAME}_demo
+  PROPERTIES
+  OUTPUT_NAME
+  demo PREFIX ""
+)
 
 # Demo executable
-add_executable(imarker_simple_demo src/imarker_simple_demo.cpp)
-target_link_libraries(imarker_simple_demo
+add_executable(${PROJECT_NAME}_imarker_simple_demo src/imarker_simple_demo.cpp)
+target_link_libraries(${PROJECT_NAME}_imarker_simple_demo
   ${catkin_LIBRARIES} ${PROJECT_NAME} ${PROJECT_NAME}_imarker_simple
+)
+set_target_properties(${PROJECT_NAME}_imarker_simple_demo
+  PROPERTIES
+  OUTPUT_NAME
+  imarker_simple_demo PREFIX ""
 )
 
 ##########
@@ -174,7 +184,7 @@ install(FILES
 )
 
 # Install executables
-install(TARGETS ${PROJECT_NAME}_demo imarker_simple_demo
+install(TARGETS ${PROJECT_NAME}_demo ${PROJECT_NAME}_imarker_simple_demo
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )


### PR DESCRIPTION
This silents some `catkin_lint` warnings

# Before
```bash
$ catkin_lint -W3 .
rviz_visual_tools: notice: target name 'imarker_simple_demo' might not be sufficiently unique
rviz_visual_tools: CMakeLists.txt(90): notice: list of source files should be sorted
rviz_visual_tools: CMakeLists.txt(177): notice: list TARGETS should be sorted
catkin_lint: checked 1 packages and found 3 problems
```

# After
```bash
catkin_lint -W3 .
rviz_visual_tools: CMakeLists.txt(90): notice: list of source files should be sorted
catkin_lint: checked 1 packages and found 1 problems
```

You can't do much about the last warning because `catkin_lint` expect sorted lists of files even with when variables are used.