### PR TITLE
Fix node type in demo launch files

### DIFF
--- a/launch/demo.launch
+++ b/launch/demo.launch
@@ -6,7 +6,7 @@
 
   <!-- Start demo -->
   <node name="rviz_visual_tools_demo" launch-prefix="$(arg launch_prefix)" pkg="rviz_visual_tools"
-	type="rviz_visual_tools_demo" output="screen">
+	type="demo" output="screen">
   </node>
 
 </launch>

--- a/launch/demo_combined.launch
+++ b/launch/demo_combined.launch
@@ -14,7 +14,7 @@
 
   <!-- Start demo -->
   <node name="rviz_visual_tools_demo" launch-prefix="$(arg launch_prefix)" pkg="rviz_visual_tools"
-	type="rviz_visual_tools_demo" output="screen">
+	type="demo" output="screen">
   </node>
 
 </launch>


### PR DESCRIPTION
I forgot to change the names of the nodes in the launch files after renaming them (https://github.com/PickNikRobotics/rviz_visual_tools/pull/98).

This fixes the launch files for the demo.