### PR TITLE
[Windows][melodic] Enable Windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,17 @@
 cmake_minimum_required(VERSION 2.8.6)
 project(rviz_visual_tools)
 
-add_definitions(-std=c++11)
+if(NOT MSVC)
+  add_compile_options(-std=c++11)
+  # Warnings
+  add_definitions(-W -Wall -Wextra
+    #-Wcast-qual
+    -Wwrite-strings -Wunreachable-code -Wpointer-arith
+    -Winit-self -Wredundant-decls
+    -Wno-unused-parameter -Wno-unused-function)
+endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-
-# Warnings
-add_definitions(-W -Wall -Wextra
-  #-Wcast-qual
-  -Wwrite-strings -Wunreachable-code -Wpointer-arith
-  -Winit-self -Wredundant-decls
-  -Wno-unused-parameter -Wno-unused-function)
 
 find_package(catkin REQUIRED COMPONENTS
   eigen_conversions
@@ -168,6 +169,10 @@ install(
     ${PROJECT_NAME}_remote_control
   LIBRARY DESTINATION
     ${CATKIN_PACKAGE_LIB_DESTINATION}
+  ARCHIVE DESTINATION
+    ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION
+    ${CATKIN_GLOBAL_BIN_DESTINATION}
 )
 
 # Install header files
@@ -186,5 +191,6 @@ install(FILES
 # Install executables
 install(TARGETS ${PROJECT_NAME}_demo ${PROJECT_NAME}_imarker_simple_demo
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/include/rviz_visual_tools/rviz_visual_tools.h
+++ b/include/rviz_visual_tools/rviz_visual_tools.h
@@ -68,6 +68,18 @@
 #include <rviz_visual_tools/deprecation.h>
 #include <rviz_visual_tools/remote_control.h>
 
+// Import/export for windows dll's and visibility for gcc shared libraries.
+
+#ifdef ROS_BUILD_SHARED_LIBS // ros is being built around shared libraries
+  #ifdef rviz_visual_tools_EXPORTS // we are building a shared lib/dll
+    #define RVIZ_VISUAL_TOOLS_DECL ROS_HELPER_EXPORT
+  #else // we are using shared lib/dll
+    #define RVIZ_VISUAL_TOOLS_DECL ROS_HELPER_IMPORT
+  #endif
+#else // ros is being built around static libraries
+  #define RVIZ_VISUAL_TOOLS_DECL
+#endif
+
 namespace rviz_visual_tools
 {
 // Default constants
@@ -1046,7 +1058,7 @@ protected:
   ros::NodeHandle nh_;
 
   // Short name for this class
-  static const std::string name_;
+  static RVIZ_VISUAL_TOOLS_DECL const std::string name_;
 
   // Optional remote control
   RemoteControlPtr remote_control_;


### PR DESCRIPTION
Enable Windows build for `rviz_visual_tools`:

* Follow `catkin` guidance to install binaries to the correct locations.
  http://docs.ros.org/kinetic/api/catkin/html/howto/format1/building_libraries.html
  http://docs.ros.org/kinetic/api/catkin/html/howto/format1/building_executables.html

* Use the `win_ros` conventions to handle DLL export issues: 
  http://wiki.ros.org/win_ros/Contributing/Dll%20Exports
  `WINDOWS_EXPORT_ALL_SYMBOLS` is enabled from `catkin` but there are limitation for that approach, so this DLL export change is still required in some cases. For details, please see [here](https://blog.kitware.com/create-dlls-on-windows-without-declspec-using-new-cmake-export-all-feature/).
   
* Conditionally include the GCC specific warning and compiler flags to unblock MSVC build.
