### PR TITLE
Make `rviz_visual_tools` publish triangle mesh and `tf_visual_tools` clean published transforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(catkin REQUIRED COMPONENTS
   eigen_stl_containers
   geometry_msgs
   graph_msgs
+  shape_msgs
   roscpp
   roslint
   rostest
@@ -64,6 +65,7 @@ catkin_package(
     eigen_conversions
     geometry_msgs
     graph_msgs
+    shape_msgs
     roscpp
     sensor_msgs
     std_msgs

--- a/include/rviz_visual_tools/rviz_visual_tools.h
+++ b/include/rviz_visual_tools/rviz_visual_tools.h
@@ -57,6 +57,7 @@
 #include <boost/shared_ptr.hpp>
 
 // Messages
+#include <shape_msgs/Mesh.h>
 #include <std_msgs/ColorRGBA.h>
 #include <graph_msgs/GeometryGraph.h>
 #include <geometry_msgs/PoseArray.h>
@@ -818,6 +819,22 @@ public:
                    const std::string& ns = "mesh", std::size_t id = 0);
   bool publishMesh(const geometry_msgs::Pose& pose, const std::string& file_name, colors color = CLEAR,
                    double scale = 1, const std::string& ns = "mesh", std::size_t id = 0);
+
+  /**
+   * \brief Display a mesh from triangles and vertices
+   * \param pose - the location to publish the marker with respect to the base frame
+   * \param mesh - shape_msgs::Mesh contains the triangles and vertices
+   * \param color - an enum pre-defined name of a color
+   * \param scale - an enum pre-defined name of a size
+   * \param ns - namespace of marker
+   * \param id - unique counter of mesh that allows you to overwrite a previous mesh. if 0, defaults
+   * to incremental counter
+   * \return true on success
+   */
+  bool publishMesh(const Eigen::Isometry3d& pose, const shape_msgs::Mesh& mesh, colors color = CLEAR, double scale = 1,
+                   const std::string& ns = "mesh", std::size_t id = 0);
+  bool publishMesh(const geometry_msgs::Pose& pose, const shape_msgs::Mesh& mesh, colors color = CLEAR, double scale = 1,
+                   const std::string& ns = "mesh", std::size_t id = 0);
 
   /**
    * \brief Display a graph

--- a/include/rviz_visual_tools/tf_visual_tools.h
+++ b/include/rviz_visual_tools/tf_visual_tools.h
@@ -77,6 +77,11 @@ public:
   bool publishTransform(const Eigen::Isometry3d& transform, const std::string& from_frame, const std::string& to_frame);
 
   /**
+   * \brief Clear all transforms
+   */
+  void clearAllTransforms();
+
+  /**
    * \brief At a certain frequency update the tf transforms that we are tracking
    *        This is called internally by a clock, you should not need to use this
    *        TODO: make private in next release?

--- a/package.xml
+++ b/package.xml
@@ -20,6 +20,7 @@
   <depend>sensor_msgs</depend>
   <depend>eigen_conversions</depend>
   <depend>geometry_msgs</depend>
+  <depend>shape_msgs</depend>
   <depend>roscpp</depend>
   <depend>tf_conversions</depend>
   <depend>visualization_msgs</depend>

--- a/src/rviz_visual_tools.cpp
+++ b/src/rviz_visual_tools.cpp
@@ -1605,6 +1605,51 @@ bool RvizVisualTools::publishMesh(const geometry_msgs::Pose& pose, const std::st
   return publishMarker(mesh_marker_);
 }
 
+bool RvizVisualTools::publishMesh(const Eigen::Isometry3d& pose, const shape_msgs::Mesh& mesh, colors color, 
+                                  double scale, const std::string& ns, std::size_t id)
+{
+  return publishMesh(convertPose(pose), mesh, color, scale, ns, id);
+}
+
+bool RvizVisualTools::publishMesh(const geometry_msgs::Pose& pose, const shape_msgs::Mesh& mesh, colors color, 
+                                  double scale, const std::string& ns, std::size_t id)
+{
+  triangle_marker_.header.stamp = ros::Time::now();
+
+  if (id == 0)
+  {
+    triangle_marker_.id++;
+  }
+  else
+  {
+    triangle_marker_.id = id;
+  }
+
+  // Set the mesh
+  triangle_marker_.points.clear();
+  for (const shape_msgs::MeshTriangle& triangle : mesh.triangles)
+    for (const uint32_t & index : triangle.vertex_indices)
+      triangle_marker_.points.push_back(mesh.vertices[index]);
+
+  // Set the pose
+  triangle_marker_.pose = pose;
+
+  // Set marker size
+  triangle_marker_.scale.x = scale;
+  triangle_marker_.scale.y = scale;
+  triangle_marker_.scale.z = scale;
+
+  // Set the namespace and id for this marker.  This serves to create a unique
+  // ID
+  triangle_marker_.ns = ns;
+
+  // Set marker color
+  triangle_marker_.color = getColor(color);
+
+  // Helper for publishing rviz markers
+  return publishMarker(triangle_marker_);
+}
+
 bool RvizVisualTools::publishGraph(const graph_msgs::GeometryGraph& graph, colors color, double radius)
 {
   // Track which pairs of nodes we've already connected since graph is

--- a/src/tf_visual_tools.cpp
+++ b/src/tf_visual_tools.cpp
@@ -96,6 +96,11 @@ bool TFVisualTools::publishTransform(const Eigen::Isometry3d& transform, const s
   return true;
 }
 
+void TFVisualTools::clearAllTransforms()
+{
+  transforms_.clear();
+}
+
 void TFVisualTools::publishAllTransforms(const ros::TimerEvent& /*e*/)
 {
   ROS_DEBUG_STREAM_NAMED("tf_visual_tools", "Publishing transforms");


### PR DESCRIPTION
In this PR, I would like to propose two changes:
* I try to publish the camera FOV marker shown below, but I only found the function to publish from the mesh source file, instead of publishing from the triangle mesh created online. Therefore, I propose to add a feature for this.

![fov_panda](https://user-images.githubusercontent.com/43195064/55863783-d014ba80-5bad-11e9-831b-faaf615dac43.png)

* In the second change, I would like to make it possible that the transforms published by `tf_visual_tools` can be reset. This can allow me to publish a new transform with a different `from_frame` to replace a previously published transform, otherwise they will coexist.