### PR TITLE
Remove auto-bot for assignees, update reviewers

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -2,17 +2,19 @@
 addReviewers: true
 
 # Set to true to add assignees to pull requests
-addAssignees: true
+addAssignees: false
 
 # A list of reviewers to be added to pull requests (GitHub user name)
 reviewers:
   - davetcoleman
   - mlautman
-  - mcevoyandy
   - nbbrooks
   - henningkayser
   - tylerjw
-
+  - JafarAbdi
+  - guilesn
+  - mamoll
+  
 # A list of keywords to be skipped the process that add reviewers if pull requests include it
 #skipKeywords:
 #  - wip


### PR DESCRIPTION
@mamoll fyi we use a bot to auto-assign PRs for some of our repos, though the OA can always manually assign people also (like I did here)

fyi @JafarAbdi this answers your question about who to assign it to