### PR TITLE
Fix rviz_visual_tools_gui

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,11 @@ find_package(tf2 REQUIRED)
 find_package(tf2_eigen REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 
+find_package(pluginlib REQUIRED)
 find_package(interactive_markers REQUIRED)
+find_package(rviz_common REQUIRED)
+find_package(rviz_rendering REQUIRED)
+find_package(rviz_default_plugins REQUIRED)
 
 find_package(Qt5 REQUIRED COMPONENTS Widgets)
 
@@ -58,18 +62,38 @@ if(NOT DEFINED BUILD_SHARED_LIBS)
 endif()
 
 # Rviz GUI library
-# set(SOURCE_FILES
-  # src/${PROJECT_NAME}_gui.cpp
-  # src/key_tool.cpp
-# )
-# add_library(${PROJECT_NAME}_gui ${SOURCE_FILES} src/remote_control.cpp)
-# target_include_directories(${PROJECT_NAME}_gui PUBLIC
-  # ${OGRE_INCLUDE_DIRS}
-# )
-# target_link_libraries(${PROJECT_NAME}_gui Qt5::Widgets)
-# ament_target_dependencies(${PROJECT_NAME}_gui
-  # rclcpp
-# )
+ set(SOURCE_FILES
+   src/${PROJECT_NAME}_gui.cpp
+   src/key_tool.cpp
+   src/remote_control.cpp
+ )
+set(HEADER_FILES
+    include/${PROJECT_NAME}/${PROJECT_NAME}_gui.hpp
+    include/${PROJECT_NAME}/key_tool.hpp
+    include/${PROJECT_NAME}/remote_control.hpp
+    include/${PROJECT_NAME}/remote_reciever.hpp
+    )
+
+add_library(${PROJECT_NAME}_gui SHARED ${SOURCE_FILES} ${HEADER_FILES})
+ament_target_dependencies(${PROJECT_NAME}_gui
+        rclcpp
+        rviz_common
+        rviz_rendering
+        rviz_default_plugins
+        )
+target_include_directories(${PROJECT_NAME}_gui PUBLIC
+   include
+   ${OGRE_INCLUDE_DIRS}
+   ${rviz_rendering_INCLUDE_DIRS}
+   ${rviz_common_INCLUDE_DIRS}
+   ${rviz_default_plugins_INCLUDE_DIRS}
+)
+target_link_libraries(${PROJECT_NAME}_gui Qt5::Widgets)
+# prevent pluginlib from using boost
+target_compile_definitions(${PROJECT_NAME}_gui PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
+## Causes the visibility macros to use dllexport rather than dllimport (for Windows, when your plugin should be used as library)
+#target_compile_definitions(${PROJECT_NAME}_gui PRIVATE "RVIZ_DEFAULT_PLUGINS_BUILDING_LIBRARY")
+pluginlib_export_plugin_description_file(rviz_common plugin_description.xml)
 
 add_library(${PROJECT_NAME}_remote_control SHARED
   src/remote_control.cpp
@@ -177,11 +201,11 @@ install(
   TARGETS
     ${PROJECT_NAME}
     ${PROJECT_NAME}_remote_control
-    # ${PROJECT_NAME}_gui
+    ${PROJECT_NAME}_gui
     ${PROJECT_NAME}_imarker_simple
   EXPORT
     ${PROJECT_NAME}
-    # ${PROJECT_NAME}_gui
+    #${PROJECT_NAME}_gui
     # ${PROJECT_NAME}_imarker_simple
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
@@ -217,13 +241,16 @@ ament_export_dependencies(geometry_msgs
   Eigen3
   eigen_stl_containers
   interactive_markers
+  rviz_common
+  rviz_rendering
+  rviz_default_plugins
 )
 ament_export_include_directories(include)
 ament_export_libraries(
   ${PROJECT_NAME}
   ${PROJECT_NAME}_remote_control
   ${PROJECT_NAME}_imarker_simple
-  # ${PROJECT_NAME}_gui
+  ${PROJECT_NAME}_gui
 )
 
 ##########

--- a/include/rviz_visual_tools/key_tool.hpp
+++ b/include/rviz_visual_tools/key_tool.hpp
@@ -31,8 +31,8 @@
 
 #ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
 
-#include <rviz/tool.h>
-#include <rviz/default_plugin/tools/move_tool.h>
+#include <rviz_common/tool.hpp>
+#include <rviz_default_plugins/tools/move/move_tool.hpp>
 
 #include <QCursor>
 #include <QObject>
@@ -42,7 +42,7 @@
 
 namespace rviz_visual_tools
 {
-class KeyTool : public rviz::Tool
+class KeyTool : public rviz_common::Tool
 {
   Q_OBJECT
 public:
@@ -54,13 +54,13 @@ public:
   virtual void activate();
   virtual void deactivate();
 
-  virtual int processKeyEvent(QKeyEvent* event, rviz::RenderPanel* panel);
-  virtual int processMouseEvent(rviz::ViewportMouseEvent& event);
+  virtual int processKeyEvent(QKeyEvent* event, rviz_common::RenderPanel* panel);
+  virtual int processMouseEvent(rviz_common::ViewportMouseEvent& event);
 
 public Q_SLOTS:
 
 protected:
-  rviz::MoveTool move_tool_;
+  rviz_default_plugins::tools::MoveTool move_tool_;
   RemoteReciever remote_reciever_;
 };
 }  // namespace rviz_visual_tools

--- a/include/rviz_visual_tools/remote_reciever.hpp
+++ b/include/rviz_visual_tools/remote_reciever.hpp
@@ -46,7 +46,7 @@ namespace rviz_visual_tools
 class RemoteReciever : public rclcpp::Node
 {
 public:
-  RemoteReciever( ) : rclcpp::Node("rviz_visual_tools_gui")
+  RemoteReciever( const std::string nodeName ) : rclcpp::Node(nodeName)
   {
     joy_publisher_ = this->create_publisher<sensor_msgs::msg::Joy>( "/rviz_visual_tools_gui", rclcpp::QoS(100));
   }

--- a/include/rviz_visual_tools/remote_reciever.hpp
+++ b/include/rviz_visual_tools/remote_reciever.hpp
@@ -43,56 +43,54 @@
 
 namespace rviz_visual_tools
 {
-class RemoteReciever
+class RemoteReciever : public rclcpp::Node
 {
 public:
-  RemoteReciever(rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr topics_interface)
+  RemoteReciever( ) : rclcpp::Node("rviz_visual_tools_gui")
   {
-    joy_publisher_ = rclcpp::create_publisher<sensor_msgs::msg::Joy>(
-        topics_interface, "/rviz_visual_tools_gui", rclcpp::QoS(100));
+    joy_publisher_ = this->create_publisher<sensor_msgs::msg::Joy>( "/rviz_visual_tools_gui", rclcpp::QoS(100));
   }
 
   void publishNext()
   {
-    ROS_DEBUG_STREAM_NAMED("gui", "Next");
+    RCLCPP_DEBUG(this->get_logger(), "Next");
     sensor_msgs::msg::Joy msg;
     msg.buttons.resize(9);
     msg.buttons[1] = 1;
-    joy_publisher_.publish(msg);
+    joy_publisher_->publish(msg);
   }
 
   void publishContinue()
   {
-    ROS_DEBUG_STREAM_NAMED("gui", "Continue");
+    RCLCPP_DEBUG(this->get_logger(), "Continue");
     sensor_msgs::msg::Joy msg;
     msg.buttons.resize(9);
     msg.buttons[2] = 1;
-    joy_publisher_.publish(msg);
+    joy_publisher_->publish(msg);
   }
 
   void publishBreak()
   {
-    ROS_DEBUG_STREAM_NAMED("gui", "Break (not implemented yet)");
-
+    RCLCPP_DEBUG(this->get_logger(), "Break");
     sensor_msgs::msg::Joy msg;
     msg.buttons.resize(9);
     msg.buttons[3] = 1;
-    joy_publisher_.publish(msg);
+    joy_publisher_->publish(msg);
   }
 
   void publishStop()
   {
-    ROS_DEBUG_STREAM_NAMED("gui", "Stop (not implemented yet)");
-
+    RCLCPP_DEBUG(this->get_logger(), "Stop");
     sensor_msgs::msg::Joy msg;
     msg.buttons.resize(9);
     msg.buttons[4] = 1;
-    joy_publisher_.publish(msg);
+    joy_publisher_->publish(msg);
   }
 
 protected:
   // The ROS publishers
-  rclcpp::Publisher joy_publisher_;
+  rclcpp::Publisher<sensor_msgs::msg::Joy>::SharedPtr joy_publisher_;
+
 };
 
 }  // end namespace rviz_visual_tools

--- a/include/rviz_visual_tools/rviz_visual_tools_gui.hpp
+++ b/include/rviz_visual_tools/rviz_visual_tools_gui.hpp
@@ -44,7 +44,7 @@
 #ifndef Q_MOC_RUN
 #include <rclcpp/rclcpp.hpp>
 
-#include <rviz/panel.h>
+#include <rviz_common/panel.hpp>
 #endif
 
 #include <QPushButton>
@@ -57,14 +57,14 @@ class QSpinBox;
 
 namespace rviz_visual_tools
 {
-class RvizVisualToolsGui : public rviz::Panel
+class RvizVisualToolsGui : public rviz_common::Panel
 {
   Q_OBJECT
 public:
   explicit RvizVisualToolsGui(QWidget* parent = 0);
 
-  virtual void load(const rviz::Config& config);
-  virtual void save(rviz::Config config) const;
+  virtual void load(const rviz_common::Config& config);
+  virtual void save(rviz_common::Config config) const;
 
 public Q_SLOTS:
 

--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>rviz_visual_tools</name>
   <version>3.7.0</version>
   <description>Utility functions for displaying and debugging data in Rviz via published markers</description>
@@ -57,6 +57,7 @@
   <test_depend>ament_lint_common</test_depend>
 
   <export>
+    <rviz plugin="plugin_description.xml"/>
     <build_type>ament_cmake</build_type>
   </export>
 

--- a/plugin_description.xml
+++ b/plugin_description.xml
@@ -1,13 +1,13 @@
-<library path="lib/librviz_visual_tools_gui">
+<library path="rviz_visual_tools_gui">
   <class name="rviz_visual_tools/RvizVisualToolsGui"
          type="rviz_visual_tools::RvizVisualToolsGui"
-         base_class_type="rviz::Panel">
+         base_class_type="rviz_common::Panel">
     <description>
       A panel widget allowing control of a ROS pipeline
     </description>
   </class>
 
-  <class name="rviz_visual_tools/KeyTool" type="rviz_visual_tools::KeyTool" base_class_type="rviz::Tool">
+  <class name="rviz_visual_tools/KeyTool" type="rviz_visual_tools::KeyTool" base_class_type="rviz_common::Tool">
     <description>
       Tool to capture keyboard input
     </description>

--- a/src/key_tool.cpp
+++ b/src/key_tool.cpp
@@ -31,12 +31,12 @@
 #include <OgreVector3.h>
 
 // Rviz
-#include <rviz/display_context.h>
-#include <rviz/load_resource.h>
-#include <rviz/properties/bool_property.h>
-#include <rviz/properties/string_property.h>
-#include <rviz/view_controller.h>
-#include <rviz/viewport_mouse_event.h>
+#include <rviz_common/display_context.hpp>
+#include <rviz_common/load_resource.hpp>
+#include <rviz_common/properties/bool_property.hpp>
+#include <rviz_common/properties/string_property.hpp>
+#include <rviz_common/view_controller.hpp>
+#include <rviz_common/viewport_mouse_event.hpp>
 
 // this package
 #include <rviz_visual_tools/key_tool.hpp>
@@ -63,7 +63,7 @@ void KeyTool::deactivate()
 {
 }
 
-int KeyTool::processKeyEvent(QKeyEvent* event, rviz::RenderPanel* panel)
+int KeyTool::processKeyEvent(QKeyEvent* event, rviz_common::RenderPanel* panel)
 {
   // move forward / backward
   switch (event->key())
@@ -86,7 +86,7 @@ int KeyTool::processKeyEvent(QKeyEvent* event, rviz::RenderPanel* panel)
   return move_tool_.processKeyEvent(event, panel);
 }
 
-int KeyTool::processMouseEvent(rviz::ViewportMouseEvent& event)
+int KeyTool::processMouseEvent(rviz_common::ViewportMouseEvent& event)
 {
   int flags = 0;
 
@@ -98,5 +98,5 @@ int KeyTool::processMouseEvent(rviz::ViewportMouseEvent& event)
 
 }  // namespace rviz_visual_tools
 
-#include <pluginlib/class_list_macros.h>
-PLUGINLIB_EXPORT_CLASS(rviz_visual_tools::KeyTool, rviz::Tool)
+#include <pluginlib/class_list_macros.hpp>
+PLUGINLIB_EXPORT_CLASS(rviz_visual_tools::KeyTool, rviz_common::Tool)

--- a/src/key_tool.cpp
+++ b/src/key_tool.cpp
@@ -46,7 +46,7 @@
 
 namespace rviz_visual_tools
 {
-KeyTool::KeyTool() = default;
+KeyTool::KeyTool() : remote_reciever_("rviz_visual_tools_keyTool"){};
 
 KeyTool::~KeyTool() = default;
 

--- a/src/rviz_visual_tools_gui.cpp
+++ b/src/rviz_visual_tools_gui.cpp
@@ -51,9 +51,9 @@
 
 namespace rviz_visual_tools
 {
-RvizVisualToolsGui::RvizVisualToolsGui(QWidget* parent) : rviz::Panel(parent)
+RvizVisualToolsGui::RvizVisualToolsGui(QWidget* parent) : rviz_common::Panel(parent)
 {
-  // Create a push button
+    // Create a push button
   btn_next_ = new QPushButton(this);
   btn_next_->setText("Next");
   connect(btn_next_, SIGNAL(clicked()), this, SLOT(moveNext()));
@@ -110,16 +110,16 @@ void RvizVisualToolsGui::moveStop()
   remote_reciever_.publishStop();
 }
 
-void RvizVisualToolsGui::save(rviz::Config config) const
+void RvizVisualToolsGui::save(rviz_common::Config config) const
 {
-  rviz::Panel::save(config);
+  rviz_common::Panel::save(config);
 }
 
-void RvizVisualToolsGui::load(const rviz::Config& config)
+void RvizVisualToolsGui::load(const rviz_common::Config& config)
 {
-  rviz::Panel::load(config);
+  rviz_common::Panel::load(config);
 }
 }  // end namespace rviz_visual_tools
 
-#include <pluginlib/class_list_macros.h>
-PLUGINLIB_EXPORT_CLASS(rviz_visual_tools::RvizVisualToolsGui, rviz::Panel)
+#include <pluginlib/class_list_macros.hpp>
+PLUGINLIB_EXPORT_CLASS(rviz_visual_tools::RvizVisualToolsGui, rviz_common::Panel)

--- a/src/rviz_visual_tools_gui.cpp
+++ b/src/rviz_visual_tools_gui.cpp
@@ -51,7 +51,7 @@
 
 namespace rviz_visual_tools
 {
-RvizVisualToolsGui::RvizVisualToolsGui(QWidget* parent) : rviz_common::Panel(parent)
+RvizVisualToolsGui::RvizVisualToolsGui(QWidget* parent) : rviz_common::Panel(parent), remote_reciever_("rviz_visual_tools_gui")
 {
     // Create a push button
   btn_next_ = new QPushButton(this);


### PR DESCRIPTION
rviz_visual_tools_gui changes / port from old ros1 rviz class names etc.

-     changed remote_reciever to inherit from rclcpp::Node hence be its own node to publish joystick messages
-     changed rviz_visual_tools_gui to use rviz2 classes (e.g. rviz_common instead of rviz)
-     some changes to CMakeLists to compile properly and rviz2 to load the plugin

plugins load fine for me with ubuntu 18.04 / eloquent and publish joystick messages properly. 

KeyTool only works for A key with me since other keys seem to jump to other tools. 