### PR TITLE
bump cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.6)
+cmake_minimum_required(VERSION 3.0.2)
 project(rviz_visual_tools)
 
 if(NOT MSVC)


### PR DESCRIPTION
Get rid of CMP0048 warning.
https://github.com/ros-planning/geometric_shapes/pull/129