### PR TITLE
Fix clang-tidy for master branch

### DIFF
--- a/src/key_tool.h
+++ b/src/key_tool.h
@@ -47,15 +47,15 @@ class KeyTool : public rviz::Tool
   Q_OBJECT
 public:
   KeyTool();
-  virtual ~KeyTool();
+  ~KeyTool() override;
 
-  virtual void onInitialize();
+  void onInitialize() override;
 
-  virtual void activate();
-  virtual void deactivate();
+  void activate() override;
+  void deactivate() override;
 
-  virtual int processKeyEvent(QKeyEvent* event, rviz::RenderPanel* panel);
-  virtual int processMouseEvent(rviz::ViewportMouseEvent& event);
+  int processKeyEvent(QKeyEvent* event, rviz::RenderPanel* panel) override;
+  int processMouseEvent(rviz::ViewportMouseEvent& event) override;
 
 public Q_SLOTS:
 

--- a/src/rviz_visual_tools_gui.h
+++ b/src/rviz_visual_tools_gui.h
@@ -61,10 +61,10 @@ class RvizVisualToolsGui : public rviz::Panel
 {
   Q_OBJECT
 public:
-  explicit RvizVisualToolsGui(QWidget* parent = 0);
+  explicit RvizVisualToolsGui(QWidget* parent = nullptr);
 
-  virtual void load(const rviz::Config& config);
-  virtual void save(rviz::Config config) const;
+  void load(const rviz::Config& config) override;
+  void save(rviz::Config config) const override;
 
 public Q_SLOTS:
 


### PR DESCRIPTION
Clang-tidy is failing on master branch [see](https://travis-ci.org/github/PickNikRobotics/rviz_visual_tools/jobs/694010598)