### PR TITLE
Change thickness of wireframe cuboid

### DIFF
--- a/include/rviz_visual_tools/rviz_visual_tools.h
+++ b/include/rviz_visual_tools/rviz_visual_tools.h
@@ -726,7 +726,7 @@ public:
    * \return true on success
    */
   bool publishWireframeCuboid(const Eigen::Isometry3d& pose, double depth, double width, double height,
-                              colors color = BLUE, const std::string& ns = "Wireframe Cuboid", std::size_t id = 0);
+                              colors color = BLUE, scales scale = SMALL, const std::string& ns = "Wireframe Cuboid", std::size_t id = 0);
 
   /**
    * \brief Publish transformed wireframe cuboid. Useful eg to show an oriented bounding box.
@@ -739,7 +739,7 @@ public:
    * \return true on success
    */
   bool publishWireframeCuboid(const Eigen::Isometry3d& pose, const Eigen::Vector3d& min_point,
-                              const Eigen::Vector3d& max_point, colors color = BLUE,
+                              const Eigen::Vector3d& max_point, colors color = BLUE, scales scale = SMALL,
                               const std::string& ns = "Wireframe Cuboid", std::size_t id = 0);
 
   /**

--- a/src/rviz_visual_tools.cpp
+++ b/src/rviz_visual_tools.cpp
@@ -2143,16 +2143,16 @@ bool RvizVisualTools::publishPolygon(const geometry_msgs::Polygon& polygon, colo
 }
 
 bool RvizVisualTools::publishWireframeCuboid(const Eigen::Isometry3d& pose, double depth, double width, double height,
-                                             colors color, const std::string& ns, std::size_t id)
+                                             colors color, scales scale, const std::string& ns, std::size_t id)
 {
   Eigen::Vector3d min_point, max_point;
   min_point << -depth / 2, -width / 2, -height / 2;
   max_point << depth / 2, width / 2, height / 2;
-  return publishWireframeCuboid(pose, min_point, max_point, color, ns, id);
+  return publishWireframeCuboid(pose, min_point, max_point, color, scale, ns, id);
 }
 
 bool RvizVisualTools::publishWireframeCuboid(const Eigen::Isometry3d& pose, const Eigen::Vector3d& min_point,
-                                             const Eigen::Vector3d& max_point, colors color, const std::string& ns,
+                                             const Eigen::Vector3d& max_point, colors color, scales scale, const std::string& ns,
                                              std::size_t id)
 {
   // Extract 8 cuboid vertices
@@ -2188,7 +2188,7 @@ bool RvizVisualTools::publishWireframeCuboid(const Eigen::Isometry3d& pose, cons
   }
 
   std_msgs::ColorRGBA this_color = getColor(color);
-  line_list_marker_.scale = getScale(XXSMALL);
+  line_list_marker_.scale = getScale(scale);
   line_list_marker_.scale.y = 0;
   line_list_marker_.scale.z = 0;
   line_list_marker_.color = this_color;


### PR DESCRIPTION
The only thickness available for wireframe cuboids was previously XXSMALL. This can be hard to see at larger scales. Thus, I've added an optional parameter to the publishWireframeCuboid functions.