### PR TITLE
[maint] add soname versions to libraries

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog for package rviz_visual_tools
 
 3.9.1 (2020-10-09)
 ------------------
+* [maint] add soname versions to libraries (`#166 <https://github.com/tylerjw/rviz_visual_tools/issues/166>`_)
 * [maint] Apply clang-format-10 (`#173 <https://github.com/tylerjw/rviz_visual_tools/issues/173>`_)
 * Contributors: Tyler Weaver
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,10 +94,12 @@ set(SOURCE_FILES
 
 # Rviz GUI library
 add_library(${PROJECT_NAME}_gui ${SOURCE_FILES} src/remote_control.cpp)
+set_target_properties(${PROJECT_NAME}_gui PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${PROJECT_NAME}_gui ${rviz_DEFAULT_PLUGIN_LIBRARIES} ${QT_LIBRARIES} ${catkin_LIBRARIES})
 
 # Remote control library
 add_library(${PROJECT_NAME}_remote_control src/remote_control.cpp)
+set_target_properties(${PROJECT_NAME}_remote_control PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${PROJECT_NAME}_remote_control ${catkin_LIBRARIES})
 
 # Visualization Tools Library
@@ -105,6 +107,7 @@ add_library(${PROJECT_NAME}
   src/${PROJECT_NAME}.cpp
   src/tf_visual_tools.cpp
 )
+set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${PROJECT_NAME}
   ${PROJECT_NAME}_remote_control
   ${catkin_LIBRARIES}
@@ -115,6 +118,7 @@ target_link_libraries(${PROJECT_NAME}
 add_library(${PROJECT_NAME}_imarker_simple
   src/imarker_simple.cpp
 )
+set_target_properties(${PROJECT_NAME}_imarker_simple PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 target_link_libraries(${PROJECT_NAME}_imarker_simple
   ${catkin_LIBRARIES}
   ${Boost_LIBRARIES}


### PR DESCRIPTION
This adds the soname versions to the libraries in anticipation of a Noetic release so if we do want to release Noetic a second time in the future with breaking changes the version of the library increases and it is discovered while linking if someone has linked incompatible versions.