### PR TITLE
Fixes & improvements for deleting markers

### DIFF
--- a/include/rviz_visual_tools/rviz_visual_tools.hpp
+++ b/include/rviz_visual_tools/rviz_visual_tools.hpp
@@ -228,6 +228,12 @@ public:
   bool deleteAllMarkers();
 
   /**
+   * \brief Tell Rviz to clear all markers on a particular display in a particular namespace.
+   * \return true if we published a marker message
+   */
+  bool deleteAllMarkers(const std::string& ns);
+
+  /**
    * \brief Reset the id's of all published markers so that they overwrite themselves in the future
    *        NOTE you may prefer deleteAllMarkers()
    */
@@ -1213,6 +1219,39 @@ public:
 
   /** \brief Pre-load remote control */
   void setRemoteControl(const RemoteControlPtr& remote_control);
+
+  /** \brief Get the latest ID of arrow_marker_ */
+  int32_t getArrowId() const;
+
+  /** \brief Get the latest ID of sphere_marker_ */
+  int32_t getSphereId() const;
+
+  /** \brief Get the latest ID of block_marker_*/
+  int32_t getBlockId() const;
+
+  /** \brief Get the latest ID of cylinder_marker_*/
+  int32_t getCylinderId() const;
+
+  /** \brief Get the latest ID of mesh_marker_*/
+  int32_t getMeshId() const;
+
+  /** \brief Get the latest ID of text_marker_*/
+  int32_t getTextId() const;
+
+  /** \brief Get the latest ID of cuboid_marker_*/
+  int32_t getCuboidId() const;
+
+  /** \brief Get the latest ID of line_strip_marker_*/
+  int32_t getLineStripId() const;
+
+  /** \brief Get the latest ID of line_list_marker_*/
+  int32_t getLineListId() const;
+
+  /** \brief Get the latest ID of spheres_marker_*/
+  int32_t getSpheresId() const;
+
+  /** \brief Get the latest ID of triangle_marker_*/
+  int32_t getTriangleId() const;
 
 protected:
   // Node Interfaces

--- a/src/rviz_visual_tools.cpp
+++ b/src/rviz_visual_tools.cpp
@@ -109,6 +109,14 @@ bool RvizVisualTools::deleteAllMarkers()
   return publishMarker(reset_marker_);
 }
 
+bool RvizVisualTools::deleteAllMarkers(const std::string& ns)
+{
+  visualization_msgs::msg::Marker delete_ns_marker = reset_marker_;
+  delete_ns_marker.header.stamp = builtin_interfaces::msg::Time();
+  delete_ns_marker.ns = ns;
+  return publishMarker(delete_ns_marker);
+}
+
 void RvizVisualTools::resetMarkerCounts()
 {
   arrow_marker_.id = 0;
@@ -129,7 +137,7 @@ bool RvizVisualTools::loadRvizMarkers()
   // Load reset marker -------------------------------------------------
   reset_marker_.header.frame_id = base_frame_;
   reset_marker_.header.stamp = builtin_interfaces::msg::Time();
-  reset_marker_.ns = "deleteAllMarkers";  // helps during debugging
+  reset_marker_.ns = "";  // needs to be empty in order for rviz to delete all markers
   reset_marker_.action = visualization_msgs::msg::Marker::DELETEALL;
   reset_marker_.pose.orientation.w = 1;
 
@@ -2981,6 +2989,61 @@ void RvizVisualTools::setRemoteControl(const RemoteControlPtr& remote_control)
                 "Overwriting existing remote_control_. there should be no reason to do that");
   }
   remote_control_ = remote_control;
+}
+
+int32_t RvizVisualTools::getArrowId() const
+{
+  return arrow_marker_.id;
+}
+
+int32_t RvizVisualTools::getSphereId() const
+{
+  return sphere_marker_.id;
+}
+
+int32_t RvizVisualTools::getBlockId() const
+{
+  return block_marker_.id;
+}
+
+int32_t RvizVisualTools::getCylinderId() const
+{
+  return cylinder_marker_.id;
+}
+
+int32_t RvizVisualTools::getMeshId() const
+{
+  return mesh_marker_.id;
+}
+
+int32_t RvizVisualTools::getTextId() const
+{
+  return text_marker_.id;
+}
+
+int32_t RvizVisualTools::getCuboidId() const
+{
+  return cuboid_marker_.id;
+}
+
+int32_t RvizVisualTools::getLineStripId() const
+{
+  return line_strip_marker_.id;
+}
+
+int32_t RvizVisualTools::getLineListId() const
+{
+  return line_list_marker_.id;
+}
+
+int32_t RvizVisualTools::getSpheresId() const
+{
+  return spheres_marker_.id;
+}
+
+int32_t RvizVisualTools::getTriangleId() const
+{
+  return triangle_marker_.id;
 }
 
 }  // namespace rviz_visual_tools


### PR DESCRIPTION
- Adds ability to delete all markers in a given namespace
- deleting all markers was previously broken, as it did not have an empty namespace, which is expected by rviz
- added getters for marker ID's so deleteMarker can be called with an ID