### PR TITLE
Move pub_rviz_markers_ to it's own callback queue

### DIFF
--- a/include/rviz_visual_tools/rviz_visual_tools.h
+++ b/include/rviz_visual_tools/rviz_visual_tools.h
@@ -38,6 +38,7 @@
 
 #pragma once
 
+#include <ros/callback_queue.h>
 #include <ros/ros.h>
 
 // C++
@@ -188,6 +189,8 @@ private:
    * \brief Shared function for initilization by constructors
    */
   void initialize();
+
+  ros::CallbackQueue vis_marker_queue_;
 
 public:
   /**

--- a/src/rviz_visual_tools.cpp
+++ b/src/rviz_visual_tools.cpp
@@ -280,7 +280,9 @@ void RvizVisualTools::loadMarkerPub(bool wait_for_subscriber, bool latched)
   }
 
   // Rviz marker publisher
-  pub_rviz_markers_ = nh_.advertise<visualization_msgs::MarkerArray>(marker_topic_, 10, latched);
+  ros::NodeHandle nh(nh_.getNamespace());
+  nh.setCallbackQueue(&vis_marker_queue_);
+  pub_rviz_markers_ = nh.advertise<visualization_msgs::MarkerArray>(marker_topic_, 10, latched);
   ROS_DEBUG_STREAM_NAMED(LOGNAME, "Publishing Rviz markers on topic " << pub_rviz_markers_.getTopic());
 
   if (wait_for_subscriber)
@@ -334,7 +336,7 @@ bool RvizVisualTools::waitForSubscriber(const ros::Publisher& pub, double wait_t
                                                   "will be lost.");
       return false;
     }
-    ros::spinOnce();
+    vis_marker_queue_.callAvailable(ros::WallDuration());
 
     // Sleep
     poll_rate.sleep();


### PR DESCRIPTION
waitForSubscriber used to call ros::spinOnce() which could trigger
callbacks from other topics in other threads. In case those have a lock
to only get called once, this would look the visual_tools thread.

Closes: #146