### PR TITLE
migrate to <random>

### DIFF
--- a/include/rviz_visual_tools/rviz_visual_tools.h
+++ b/include/rviz_visual_tools/rviz_visual_tools.h
@@ -41,6 +41,7 @@
 #include <ros/ros.h>
 
 // C++
+#include <random>
 #include <string>
 #include <vector>
 
@@ -1053,6 +1054,13 @@ public:
   static int iRand(int min, int max);
 
   /**
+   * \brief Set seed for random methods above
+	*
+	* Random sampling uses std::mt19937 internally
+	*/
+  static void setRandomSeed(unsigned int seed);
+
+  /**
    * \brief Display in the console the x,y,z values of a point
    */
   static void printTranslation(const Eigen::Vector3d& translation);
@@ -1143,6 +1151,8 @@ protected:
 
   // Chose random colors from this list
   static const std::array<colors, 14> ALL_RAND_COLORS;
+
+  static std::mt19937 mt_random_engine_;
 
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW  // http://eigen.tuxfamily.org/dox/group__TopicStructHavingEigenMembers.html

--- a/include/rviz_visual_tools/rviz_visual_tools.h
+++ b/include/rviz_visual_tools/rviz_visual_tools.h
@@ -1055,9 +1055,9 @@ public:
 
   /**
    * \brief Set seed for random methods above
-	*
-	* Random sampling uses std::mt19937 internally
-	*/
+   *
+   * Random sampling uses std::mt19937 internally
+   */
   static void setRandomSeed(unsigned int seed);
 
   /**

--- a/src/imarker_simple_demo.cpp
+++ b/src/imarker_simple_demo.cpp
@@ -103,8 +103,8 @@ int main(int argc, char** argv)
   ros::init(argc, argv, "imarker_simple_demo");
   ROS_INFO_STREAM_NAMED("main", "Starting IMarkerSimpleDemo...");
 
-  // Seed random number generator
-  // srand (time(NULL));
+  // Optionally set a fixed random seed
+  // rviz_visual_tools::RvizVisualTools::setRandomSeed(0xdeadbeef);
 
   // Allow the action server to recieve and send ros messages
   ros::AsyncSpinner spinner(2);

--- a/src/rviz_visual_tools.cpp
+++ b/src/rviz_visual_tools.cpp
@@ -44,7 +44,9 @@
 #include <tf2/convert.h>
 
 // C++
+#include <chrono>
 #include <cmath>  // for random poses
+#include <random>
 #include <set>
 #include <string>
 #include <utility>
@@ -60,6 +62,8 @@ const std::string RvizVisualTools::NAME = "visual_tools";
 const std::array<colors, 14> RvizVisualTools::ALL_RAND_COLORS = { RED,        GREEN,  BLUE,   GREY,   DARK_GREY,
                                                                   WHITE,      ORANGE, YELLOW, BROWN,  PINK,
                                                                   LIME_GREEN, PURPLE, CYAN,   MAGENTA };
+
+std::mt19937 RvizVisualTools::mt_random_engine_(std::chrono::system_clock::now().time_since_epoch().count());
 
 RvizVisualTools::RvizVisualTools(std::string base_frame, std::string marker_topic, ros::NodeHandle nh)
   : nh_(nh), marker_topic_(std::move(marker_topic)), base_frame_(std::move(base_frame))
@@ -2801,26 +2805,21 @@ bool RvizVisualTools::posesEqual(const Eigen::Isometry3d& pose1, const Eigen::Is
 
 double RvizVisualTools::dRand(double min, double max)
 {
-  double d = static_cast<double>(rand()) / RAND_MAX;
-  return min + d * (max - min);
+  return std::uniform_real_distribution<double>(min,max)(mt_random_engine_);
 }
 
 float RvizVisualTools::fRand(float min, float max)
 {
-  float d = static_cast<float>(rand()) / RAND_MAX;
-  return min + d * (max - min);
+  return std::uniform_real_distribution<float>(min,max)(mt_random_engine_);
 }
 
 int RvizVisualTools::iRand(int min, int max)
 {
-  int n = max - min + 1;
-  int remainder = RAND_MAX % n;
-  int x;
-  do
-  {
-    x = rand();
-  } while (x >= RAND_MAX - remainder);
-  return min + x % n;
+  return std::uniform_int_distribution<int>(min,max)(mt_random_engine_);
+}
+
+void RvizVisualTools::setRandomSeed(unsigned int seed){
+  mt_random_engine_.seed(seed);
 }
 
 void RvizVisualTools::printTranslation(const Eigen::Vector3d& translation)


### PR DESCRIPTION
rand/srand were probably already deprecated by the time this code was written...
I took the error on MoveIt's CI as an incentive to migrate to std::random:

As example code referred to a seeding step, I added an explicit setRandomSeed to the API.

This is required to fix MoveIt's CI: https://github.com/ros-planning/moveit/pull/2792/commits/2989f44e50ea10a1bc1ef833d39bac766daf61f5

<<<
rviz_visual_tools.cpp:2810:42: error: implicit conversion from 'int' to 'float' changes value from 2147483647 to 2147483648 [-Werror,-Wimplicit-int-float-conversion]
  float d = static_cast<float>(rand()) / RAND_MAX;
                                       ~ ^~~~~~~~
/usr/include/stdlib.h:86:18: note: expanded from macro 'RAND_MAX'
                          ^~~~~~~~~~
<<<

Please review @nbbrooks @tylerjw @JafarAbdi 