### PR TITLE
Add pluginlib dependency.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -22,6 +22,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>rviz_ogre_vendor</depend>
+  <depend>pluginlib</depend>
   <depend>tf2</depend>
   <depend>tf2_eigen</depend>
   <depend>eigen_stl_containers</depend>


### PR DESCRIPTION
This package is failing to build on Rolling due to the missing pluginlib dependency declaration.

The existing dependencies do not appear to be lexically ordered so I sort of plopped pluginlib in somewhere that "seemed reasonable". I'm happy to rework this PR to fit what you need, or maintainer edits are on so you can tweak it to your preference.

This is primarily intended as notification that Rolling builds for this package are currently failing and a proposed solution for the current issue.

