### PR TITLE
Make sure to add all dependencies to the package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -21,7 +21,10 @@
 
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>rviz_common</depend>
   <depend>rviz_ogre_vendor</depend>
+  <depend>rviz_rendering</depend>
+  <depend>rviz_default_plugins</depend>
   <depend>pluginlib</depend>
   <depend>tf2</depend>
   <depend>tf2_eigen</depend>


### PR DESCRIPTION
Otherwise it will fail to build on the buildfarm.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix the failing build, e.g. https://build.ros2.org/view/Rbin_uF64/job/Rbin_uF64__rviz_visual_tools__ubuntu_focal_amd64__binary/54/console