### PR TITLE
Fix faulty templated constructor

### DIFF
--- a/include/rviz_visual_tools/tf_visual_tools.hpp
+++ b/include/rviz_visual_tools/tf_visual_tools.hpp
@@ -62,8 +62,7 @@ public:
    * \param node - a pointer to a rclcpp::Node
    * \param loop_hz - how often tf is published
    */
-  template <typename NodePtr>
-  TFVisualTools(NodePtr node, double loop_hz = 2);
+  TFVisualTools(const rclcpp::Node::SharedPtr& node, double loop_hz = 2);
   /**
    * \brief Visualize transforms in Rviz, etc
    * \return true on success

--- a/src/tf_visual_tools.cpp
+++ b/src/tf_visual_tools.cpp
@@ -46,8 +46,8 @@
 
 namespace rviz_visual_tools
 {
-template <typename NodePtr>
-TFVisualTools::TFVisualTools(NodePtr node, double loop_hz)
+
+TFVisualTools::TFVisualTools(const rclcpp::Node::SharedPtr& node, double loop_hz)
   : node_base_interface_(node->get_node_base_interface())
   , timers_interface_(node->get_node_timers_interface())
   , clock_interface_(node->get_node_clock_interface())

--- a/src/tf_visual_tools.cpp
+++ b/src/tf_visual_tools.cpp
@@ -46,7 +46,6 @@
 
 namespace rviz_visual_tools
 {
-
 TFVisualTools::TFVisualTools(const rclcpp::Node::SharedPtr& node, double loop_hz)
   : node_base_interface_(node->get_node_base_interface())
   , timers_interface_(node->get_node_timers_interface())


### PR DESCRIPTION
There was a faulty templated constructor in tf_visual_tools header causing various weird issues in moveit_calibration. This should fix it. Thanks @JafarAbdi for helping me with this.

Alternative solution at #212.