### PR TITLE
spin independent thread for RemoteControl

### DIFF
--- a/include/rviz_visual_tools/remote_control.h
+++ b/include/rviz_visual_tools/remote_control.h
@@ -45,6 +45,8 @@
 
 // ROS
 #include <ros/ros.h>
+#include <ros/callback_queue.h>
+
 #include <sensor_msgs/Joy.h>
 
 namespace rviz_visual_tools
@@ -58,6 +60,8 @@ public:
    * \brief Constructor
    */
   explicit RemoteControl(const ros::NodeHandle& nh);
+
+  ~RemoteControl();
 
   /**
    * \brief Callback from ROS topic
@@ -112,14 +116,14 @@ public:
   }
 
 private:
-  // A shared node handle
-  ros::NodeHandle nh_;
-
   // Short name for this class
   std::string name_ = "remote_control";
 
-  // Input
+  // Input and callback management
+  ros::CallbackQueue callback_queue_;
+  ros::NodeHandle nh_;
   ros::Subscriber rviz_dashboard_sub_;
+  ros::AsyncSpinner spinner_;
 
   // Debug interface
   bool is_waiting_ = false;

--- a/src/remote_control.cpp
+++ b/src/remote_control.cpp
@@ -50,16 +50,25 @@ namespace rviz_visual_tools
 /**
  * \brief Constructor
  */
-RemoteControl::RemoteControl(const ros::NodeHandle& nh) : nh_(nh)
+RemoteControl::RemoteControl(const ros::NodeHandle& nh) : nh_{ nh }, spinner_{ 1, &callback_queue_ }
 {
   std::string rviz_dashboard_topic = "/rviz_visual_tools_gui";
 
   // Subscribe to Rviz Dashboard
   const std::size_t button_queue_size = 10;
+
+  nh_.setCallbackQueue(&callback_queue_);
+
   rviz_dashboard_sub_ = nh_.subscribe<sensor_msgs::Joy>(rviz_dashboard_topic, button_queue_size,
                                                         &RemoteControl::rvizDashboardCallback, this);
-
+  spinner_.start();
   ROS_INFO_STREAM_NAMED(name_, "RemoteControl Ready.");
+}
+
+RemoteControl::~RemoteControl()
+{
+  // stop spinner explicitly for clarity.
+  spinner_.stop();
 }
 
 void RemoteControl::rvizDashboardCallback(const sensor_msgs::Joy::ConstPtr& msg)
@@ -157,7 +166,6 @@ bool RemoteControl::waitForNextStep(const std::string& caption)
   while (!next_step_ready_ && !autonomous_ && ros::ok())
   {
     ros::Duration(0.25).sleep();
-    ros::spinOnce();
   }
   if (!ros::ok())
   {
@@ -197,7 +205,6 @@ bool RemoteControl::waitForNextFullStep(const std::string& caption)
   while (!next_step_ready_ && !full_autonomous_ && ros::ok())
   {
     ros::Duration(0.25).sleep();
-    ros::spinOnce();
   }
   if (!ros::ok())
   {


### PR DESCRIPTION
The `RemoteControl` class currently [spins the global queue when waiting for the user to confirm](https://github.com/PickNikRobotics/rviz_visual_tools/blob/9b10fd2d96f9f2aa8177052e4dc35df8ce914003/src/remote_control.cpp#L16jk0).
It does so because the node handle for the subscriber that receives the feedback is usually initialized with the global callback queue. But that also means that other callbacks (including the one currently running!) can be processed in the thread that is waiting for user input and it's easy to block all available spinners or get into recursive spin calls for the same topic.

Even worse, there is no workaround: Even if the user provides a node handle with a different callback queue, the calls to `spinOnce` will not even process that queue but the method calls still invoke unwanted side-effects without serving any purpose.

Thus I modified the class to create its own spinner unconditionally.

@jspricke @tylerjw 