### PR TITLE
Migrate to Ogre.h

### DIFF
--- a/src/key_tool.cpp
+++ b/src/key_tool.cpp
@@ -27,7 +27,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include <OgreRay.h>
-#include <OgreVector3.h>
+#include <Ogre.h>
 
 // Rviz
 #include <rviz_common/display_context.hpp>


### PR DESCRIPTION
### Description

When building, I get the following message:
```
In file included from /workspaces/ros2-rolling-ws/src/rviz_visual_tools/src/key_tool.cpp:30:
/opt/ros/rolling/opt/rviz_ogre_vendor/include/OGRE/OgreVector3.h:2:62: note: ‘#pragma message: /opt/ros/rolling/opt/rviz_ogre_vendor/include/OGRE/OgreVector3.h is deprecated, migrate to Ogre.h’
    2 | #pragma message( __FILE__ " is deprecated, migrate to Ogre.h")
```

This PR uses Ogre.h instead of the deprecated OgreVector3.h as per the message suggests.