### PR TITLE
Add arbitrary color option to `publishCuboid`

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ In the following snippet we create a pose at xyz (0.1, 0.1, 0.1) and rotate the 
     // Don't forget to trigger the publisher!
     visual_tools_->trigger();
 
-For more example code see [rviz_visual_tools_demo.cpp](https://github.com/PickNikRobotics/rviz_visual_tools/blob/eloquent-devel/src/rviz_visual_tools_demo.cpp)
+For more example code see [rviz_visual_tools_demo.cpp](https://github.com/PickNikRobotics/rviz_visual_tools/blob/ros2/src/rviz_visual_tools_demo.cpp)
 
 ## Rviz GUI Usage
 **NOT PORTED**

--- a/include/rviz_visual_tools/rviz_visual_tools.hpp
+++ b/include/rviz_visual_tools/rviz_visual_tools.hpp
@@ -708,13 +708,18 @@ public:
    * \brief Display a rectangular cuboid
    * \param point1 - x,y,z top corner location of box
    * \param point2 - x,y,z bottom opposite corner location of box
-   * \param color - an enum pre-defined name of a color
+   * \param color - an enum pre-defined name of a color or a color message
    * \return true on success
    */
   bool publishCuboid(const Eigen::Vector3d& point1, const Eigen::Vector3d& point2,
                      Colors color = BLUE);
+  bool publishCuboid(const Eigen::Vector3d& point1, const Eigen::Vector3d& point2,
+                     const std_msgs::msg::ColorRGBA& color);
   bool publishCuboid(const geometry_msgs::msg::Point& point1,
                      const geometry_msgs::msg::Point& point2, Colors color = BLUE,
+                     const std::string& ns = "Cuboid", std::size_t id = 0);
+  bool publishCuboid(const geometry_msgs::msg::Point& point1,
+                     const geometry_msgs::msg::Point& point2, const std_msgs::msg::ColorRGBA& color,
                      const std::string& ns = "Cuboid", std::size_t id = 0);
 
   /**
@@ -723,13 +728,17 @@ public:
    * \param depth - depth of the box
    * \param width - width of the box
    * \param height - height of the box
-   * \param color - an enum pre-defined name of a color
+   * \param color - an enum pre-defined name of a color or a color message
    * \return true on success
    */
-  bool publishCuboid(const geometry_msgs::msg::Pose& pose, double depth, double width,
-                     double height, Colors color = BLUE);
+  bool publishCuboid(const Eigen::Isometry3d& pose, double depth, double width, double height,
+                     const std_msgs::msg::ColorRGBA& color);
   bool publishCuboid(const Eigen::Isometry3d& pose, double depth, double width, double height,
                      Colors color = BLUE);
+  bool publishCuboid(const geometry_msgs::msg::Pose& pose, double depth, double width,
+                     double height, Colors color = BLUE);
+  bool publishCuboid(const geometry_msgs::msg::Pose& pose, double depth, double width,
+                     double height, const std_msgs::msg::ColorRGBA& color);
 
   /**
    * \brief Display a marker of line

--- a/src/rviz_visual_tools.cpp
+++ b/src/rviz_visual_tools.cpp
@@ -1802,12 +1802,26 @@ bool RvizVisualTools::publishMesh(const geometry_msgs::msg::Pose& pose,
 bool RvizVisualTools::publishCuboid(const Eigen::Vector3d& point1, const Eigen::Vector3d& point2,
                                     Colors color)
 {
+  return publishCuboid(convertPoint(point1), convertPoint(point2), getColor(color));
+}
+
+bool RvizVisualTools::publishCuboid(const Eigen::Vector3d& point1, const Eigen::Vector3d& point2,
+                                    const std_msgs::msg::ColorRGBA& color)
+{
   return publishCuboid(convertPoint(point1), convertPoint(point2), color);
 }
 
 bool RvizVisualTools::publishCuboid(const geometry_msgs::msg::Point& point1,
                                     const geometry_msgs::msg::Point& point2, Colors color,
                                     const std::string& ns, std::size_t id)
+{
+  return publishCuboid(point1, point2, getColor(color), ns, id);
+}
+
+bool RvizVisualTools::publishCuboid(const geometry_msgs::msg::Point& point1,
+                                    const geometry_msgs::msg::Point& point2,
+                                    const std_msgs::msg::ColorRGBA& color, const std::string& ns,
+                                    std::size_t id)
 {
   // Set the timestamp
   cuboid_marker_.header.stamp = clock_interface_->get_clock()->now();
@@ -1822,7 +1836,7 @@ bool RvizVisualTools::publishCuboid(const geometry_msgs::msg::Point& point1,
     cuboid_marker_.id = id;
   }
 
-  cuboid_marker_.color = getColor(color);
+  cuboid_marker_.color = color;
 
   // Calculate center pose
   geometry_msgs::msg::Pose pose = getIdentityPose();
@@ -1857,16 +1871,29 @@ bool RvizVisualTools::publishCuboid(const geometry_msgs::msg::Point& point1,
 bool RvizVisualTools::publishCuboid(const Eigen::Isometry3d& pose, double depth, double width,
                                     double height, Colors color)
 {
+  return publishCuboid(convertPose(pose), depth, width, height, getColor(color));
+}
+
+bool RvizVisualTools::publishCuboid(const Eigen::Isometry3d& pose, double depth, double width,
+                                    double height, const std_msgs::msg::ColorRGBA& color)
+{
   return publishCuboid(convertPose(pose), depth, width, height, color);
 }
 
 bool RvizVisualTools::publishCuboid(const geometry_msgs::msg::Pose& pose, double depth,
                                     double width, double height, Colors color)
 {
+  return publishCuboid(pose, depth, width, height, getColor(color));
+}
+
+bool RvizVisualTools::publishCuboid(const geometry_msgs::msg::Pose& pose, double depth,
+                                    double width, double height,
+                                    const std_msgs::msg::ColorRGBA& color)
+{
   cuboid_marker_.header.stamp = clock_interface_->get_clock()->now();
 
   cuboid_marker_.id++;
-  cuboid_marker_.color = getColor(color);
+  cuboid_marker_.color = color;
 
   cuboid_marker_.pose = pose;
 


### PR DESCRIPTION
This PR expands the interfaces for `publishCuboid()` so we can pass in any general `std_msgs::msg::ColorRGBA` color rather than just the predefined enums.

I also snuck in a one-line link fix to the README