### PR TITLE
Added Foxglove Studio support for deleteAllMarkers function

### DIFF
--- a/src/rviz_visual_tools.cpp
+++ b/src/rviz_visual_tools.cpp
@@ -105,7 +105,7 @@ bool RvizVisualTools::loadRvizMarkers()
   // Load reset marker -------------------------------------------------
   reset_marker_.header.frame_id = base_frame_;
   reset_marker_.header.stamp = ros::Time();
-  reset_marker_.ns = "deleteAllMarkers";  // helps during debugging
+  reset_marker_.ns = "";
   reset_marker_.action = 3;               // TODO(davetcoleman): In ROS-J set to visualization_msgs::Marker::DELETEALL;
   reset_marker_.pose.orientation.w = 1;
 


### PR DESCRIPTION
Hello,

I know the filling up the namespace of the reset_marker_ said to be done for debugging reasons but filling it up with anything causes the Foxglove Studio to take this particular message and use the namespace to decide what namespace to remove:

https://github.com/foxglove/studio/blob/64be9e1756f4a027072eb2312a67da01122ff7e1/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicMarkers.ts#L80-L81

https://github.com/foxglove/studio/blob/64be9e1756f4a027072eb2312a67da01122ff7e1/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicMarkers.ts#L194-L215

I am suggesting we remove this one so that whole library could be used with Foxglove Studio too.