### PR TITLE
[ROS-O] add missing pluginlib dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,11 +8,12 @@ find_package(catkin REQUIRED COMPONENTS
   geometry_msgs
   graph_msgs
   interactive_markers
-  shape_msgs
+  pluginlib
   roscpp
   roslint
   rostest
   rviz
+  shape_msgs
   sensor_msgs
   std_msgs
   tf2_eigen

--- a/package.xml
+++ b/package.xml
@@ -32,6 +32,7 @@
   <depend>eigen_stl_containers</depend>
   <depend>libogre-dev</depend>
   <depend>interactive_markers</depend>
+  <depend>pluginlib</depend>
 
   <!-- Something changed in ROS Lunar / Ubuntu Zesty that requires extra QT5 dependency-->
   <!-- I suspect this depend is more than needed, but was the only dependency available -->


### PR DESCRIPTION
This is required to compile with debian's `pluginlib-dev` package which isolates the headers.
The include is required [here](https://github.com/PickNikRobotics/rviz_visual_tools/blob/8703caf0d994e346487748afdafd7c85b845031c/src/rviz_visual_tools_gui.cpp#L124-L125) and [here](https://github.com/PickNikRobotics/rviz_visual_tools/blob/8703caf0d994e346487748afdafd7c85b845031c/src/key_tool.cpp#L101-L102).