### PR TITLE
Update clang

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -15,6 +15,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4.1.1
     - uses: actions/setup-python@v5
-    - name: Install clang-format-10
-      run: sudo apt-get install clang-format-10
+    - name: Install clang-format-11
+      run: sudo apt-get install clang-format-11
     - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
       - id: clang-format
         name: clang-format
         description: Format files with ClangFormat.
-        entry: clang-format-10
+        entry: clang-format-11
         language: system
         files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|js|m|proto|vert)$
         args: ['-fallback-style=none', '-i']


### PR DESCRIPTION
Ubuntu 20.04 use clang  10 and 11.

ubuntu 20.04 will cease development on April 25.
ros 2 releases require a c++17 standard.
Clang 11 release introduces the following features:
The default C language standard used when -std= is not specified has been upgraded from gnu11 to gnu17.
For this reason is important switch to clang11 or higher.

other changes: https://releases.llvm.org/11.1.0/tools/clang/docs/index.html
