### PR TITLE
Fix missing includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,9 +36,11 @@ find_package(tf2_geometry_msgs REQUIRED)
 
 find_package(pluginlib REQUIRED)
 find_package(interactive_markers REQUIRED)
+find_package(resource_retriever REQUIRED)
 find_package(rviz_common REQUIRED)
 find_package(rviz_rendering REQUIRED)
 find_package(rviz_default_plugins REQUIRED)
+find_package(rviz_resource_interfaces REQUIRED)
 
 find_package(Qt5 REQUIRED COMPONENTS Widgets)
 
@@ -83,6 +85,7 @@ ament_target_dependencies(${PROJECT_NAME}_gui PUBLIC
   rviz_rendering
   rviz_default_plugins
   rviz_ogre_vendor
+  rviz_resource_interfaces
 )
 target_link_libraries(${PROJECT_NAME}_gui PUBLIC Qt5::Widgets)
 
@@ -229,6 +232,7 @@ ament_export_dependencies(geometry_msgs
   rviz_rendering
   rviz_default_plugins
   rviz_ogre_vendor
+  rviz_resource_interfaces
 )
 ament_export_include_directories(include)
 ament_export_libraries(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.15)
 project(rviz_visual_tools)
 
-# Default to C++14
+# Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -33,15 +33,13 @@ find_package(PkgConfig REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_eigen REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
-
+find_package(resource_retriever REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(interactive_markers REQUIRED)
-find_package(resource_retriever REQUIRED)
 find_package(rviz_common REQUIRED)
 find_package(rviz_rendering REQUIRED)
 find_package(rviz_default_plugins REQUIRED)
 find_package(rviz_resource_interfaces REQUIRED)
-
 find_package(Qt5 REQUIRED COMPONENTS Widgets)
 
 ## Qt5 boilerplate options from http://doc.qt.io/qt-5/cmake-manual.html

--- a/package.xml
+++ b/package.xml
@@ -25,6 +25,7 @@
   <depend>rviz_ogre_vendor</depend>
   <depend>rviz_rendering</depend>
   <depend>rviz_default_plugins</depend>
+  <depend>rviz_resource_interfaces</depend>
   <depend>pluginlib</depend>
   <depend>tf2</depend>
   <depend>tf2_eigen</depend>

--- a/package.xml
+++ b/package.xml
@@ -25,7 +25,7 @@
   <depend>rviz_ogre_vendor</depend>
   <depend>rviz_rendering</depend>
   <depend>rviz_default_plugins</depend>
-  <depend>rviz_resource_interfaces</depend>
+  <depend>resource_retriever</depend>
   <depend>pluginlib</depend>
   <depend>tf2</depend>
   <depend>tf2_eigen</depend>


### PR DESCRIPTION
Compile fails due to missing dependencies
--- stderr: rviz_visual_tools
/usr/bin/ld: cannot find -lresource_retriever::resource_retriever: No such file or directory
/usr/bin/ld: cannot find -lrviz_resource_interfaces::rviz_resource_interfaces__rosidl_generator_c: No such file or directory
/usr/bin/ld: cannot find -lrviz_resource_interfaces::rviz_resource_interfaces__rosidl_typesupport_introspection_c: No such file or directory
/usr/bin/ld: cannot find -lrviz_resource_interfaces::rviz_resource_interfaces__rosidl_typesupport_fastrtps_c: No such file or directory
/usr/bin/ld: cannot find -lrviz_resource_interfaces::rviz_resource_interfaces__rosidl_typesupport_c: No such file or directory
/usr/bin/ld: cannot find -lrviz_resource_interfaces::rviz_resource_interfaces__rosidl_generator_cpp: No such file or directory
/usr/bin/ld: cannot find -lrviz_resource_interfaces::rviz_resource_interfaces__rosidl_typesupport_introspection_cpp: No such file or directory
/usr/bin/ld: cannot find -lrviz_resource_interfaces::rviz_resource_interfaces__rosidl_typesupport_fastrtps_cpp: No such file or directory
/usr/bin/ld: cannot find -lrviz_resource_interfaces::rviz_resource_interfaces__rosidl_typesupport_cpp: No such file or directory
/usr/bin/ld: cannot find -lrviz_resource_interfaces::rviz_resource_interfaces__rosidl_generator_py: No such file or directory
collect2: error: ld returned 1 exit status
gmake[2]: *** [CMakeFiles/rviz_visual_tools_gui.dir/build.make:338: librviz_visual_tools_gui.so] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:213: CMakeFiles/rviz_visual_tools_gui.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
gmake: *** [Makefile:146: all] Error 2
---
Failed   <<< rviz_visual_tools [21.5s, exited with code 2]
