### PR TITLE
Update cmake requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.16)
 project(rviz_visual_tools)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)


### PR DESCRIPTION
The minimum cmake version supported in qt6 is 3.16.

https://doc.qt.io/qt-6.5/cmake-get-started.html