### PR TITLE
Replace ament_target_dependencies with target_link_libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,14 +77,14 @@ set(HEADER_FILES
     )
 
 add_library(${PROJECT_NAME}_gui SHARED ${SOURCE_FILES} ${HEADER_FILES})
-ament_target_dependencies(${PROJECT_NAME}_gui PUBLIC
-  rclcpp
-  rviz_common
-  rviz_rendering
-  rviz_default_plugins
-  rviz_ogre_vendor
+target_link_libraries(${PROJECT_NAME}_gui PUBLIC
+  rclcpp::rclcpp
+  rviz_common::rviz_common
+  rviz_rendering::rviz_rendering
+  rviz_default_plugins::rviz_default_plugins
+  rviz_ogre_vendor::OgreMain
+  Qt5::Widgets
 )
-target_link_libraries(${PROJECT_NAME}_gui PUBLIC Qt5::Widgets)
 
 # prevent pluginlib from using boost
 target_compile_definitions(${PROJECT_NAME}_gui PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
@@ -98,18 +98,18 @@ add_library(${PROJECT_NAME}_remote_control SHARED
 # Needed for M_PI on Windows
 target_compile_definitions(${PROJECT_NAME}_remote_control PRIVATE _USE_MATH_DEFINES)
 
-ament_target_dependencies(${PROJECT_NAME}_remote_control
-  rclcpp
-  rclcpp_components
-  visualization_msgs
-  tf2
-  tf2_eigen
-  tf2_geometry_msgs
-  sensor_msgs
-  shape_msgs
-  std_msgs
-  trajectory_msgs
-  eigen_stl_containers
+target_link_libraries(${PROJECT_NAME}_remote_control
+  rclcpp::rclcpp
+  rclcpp_components::component
+  ${visualization_msgs_TARGETS}
+  tf2::tf2
+  tf2_eigen::tf2_eigen
+  ${tf2_geometry_msgs_TARGETS}
+  ${sensor_msgs_TARGETS}
+  ${shape_msgs_TARGETS}
+  ${std_msgs_TARGETS}
+  ${trajectory_msgs_TARGETS}
+  eigen_stl_containers::eigen_stl_containers
 )
 
 # Visualization Tools Library
@@ -118,22 +118,20 @@ add_library(${PROJECT_NAME} SHARED
   src/tf_visual_tools.cpp
 )
 target_compile_definitions(${PROJECT_NAME} PRIVATE _USE_MATH_DEFINES)
-ament_target_dependencies(${PROJECT_NAME} PUBLIC Eigen3)
 target_link_libraries(${PROJECT_NAME}
   ${PROJECT_NAME}_remote_control
-)
-ament_target_dependencies(${PROJECT_NAME}
-  rclcpp
-  rclcpp_components
-  visualization_msgs
-  tf2
-  tf2_eigen
-  tf2_geometry_msgs
-  sensor_msgs
-  shape_msgs
-  std_msgs
-  trajectory_msgs
-  eigen_stl_containers
+  Eigen3::Eigen
+  rclcpp::rclcpp
+  rclcpp_components::component
+  ${visualization_msgs_TARGETS}
+  tf2::tf2
+  tf2_eigen::tf2_eigen
+  ${tf2_geometry_msgs_TARGETS}
+  ${sensor_msgs_TARGETS}
+  ${shape_msgs_TARGETS}
+  ${std_msgs_TARGETS}
+  ${trajectory_msgs_TARGETS}
+  eigen_stl_containers::eigen_stl_containers
 )
 
 # Library
@@ -143,15 +141,13 @@ add_library(${PROJECT_NAME}_imarker_simple SHARED
 target_compile_definitions(${PROJECT_NAME}_imarker_simple PRIVATE _USE_MATH_DEFINES)
 target_link_libraries(${PROJECT_NAME}_imarker_simple
   ${PROJECT_NAME}
-)
-ament_target_dependencies(${PROJECT_NAME}_imarker_simple
-  rclcpp
-  interactive_markers
-  geometry_msgs
-  visualization_msgs
-  sensor_msgs
-  eigen_stl_containers
-  Eigen3
+  rclcpp::rclcpp
+  interactive_markers::interactive_markers
+  ${geometry_msgs_TARGETS}
+  ${visualization_msgs_TARGETS}
+  ${sensor_msgs_TARGETS}
+  eigen_stl_containers::eigen_stl_containers
+  Eigen3::Eigen
 )
 
 # Demo executable
@@ -161,11 +157,9 @@ add_executable(${PROJECT_NAME}_demo
 target_compile_definitions(${PROJECT_NAME}_demo PRIVATE _USE_MATH_DEFINES)
 target_link_libraries(${PROJECT_NAME}_demo
   ${PROJECT_NAME}
-)
-ament_target_dependencies(${PROJECT_NAME}_demo
-  rclcpp
-  geometry_msgs
-  std_msgs
+  rclcpp::rclcpp
+  ${geometry_msgs_TARGETS}
+  ${std_msgs_TARGETS}
 )
 
 # Demo executable
@@ -174,9 +168,7 @@ add_executable(${PROJECT_NAME}_imarker_simple_demo
 target_compile_definitions(${PROJECT_NAME}_imarker_simple_demo PRIVATE _USE_MATH_DEFINES)
 target_link_libraries(${PROJECT_NAME}_imarker_simple_demo
   ${PROJECT_NAME}_imarker_simple
-)
-ament_target_dependencies(${PROJECT_NAME}_imarker_simple_demo
-  rclcpp
+  rclcpp::rclcpp
 )
 
 #############
@@ -248,11 +240,9 @@ if (BUILD_TESTING)
     tests/rvt_test.cpp
     TIMEOUT 180)
   target_compile_definitions(${PROJECT_NAME}_rvt_test PRIVATE _USE_MATH_DEFINES)
-  ament_target_dependencies(${PROJECT_NAME}_rvt_test
-    rclcpp
-  )
   target_link_libraries(${PROJECT_NAME}_rvt_test
     ${PROJECT_NAME}
+    rclcpp::rclcpp
   )
 endif()
 


### PR DESCRIPTION
`ament_target_dependencies` is deprecated on `kilted` and removed in `rolling`,  It will require a new release on `rolling`.


Debs are broken https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__rviz_visual_tools__ubuntu_noble_amd64__binary/