### PR TITLE
Fix additional geometry2 tf2 .h deprecations

### DIFF
--- a/src/rviz_visual_tools.cpp
+++ b/src/rviz_visual_tools.cpp
@@ -42,15 +42,18 @@
 #include <rviz_visual_tools/rviz_visual_tools.hpp>
 
 // Conversions
-#include <tf2/convert.h>
-#include <tf2/LinearMath/Vector3.h>
-#include <tf2/LinearMath/Quaternion.h>
 #if __has_include(<tf2_eigen/tf2_eigen.hpp>)
 #include <tf2_eigen/tf2_eigen.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include <tf2/convert.hpp>
+#include <tf2/LinearMath/Vector3.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
 #else
 #include <tf2_eigen/tf2_eigen.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2/convert.h>
+#include <tf2/LinearMath/Vector3.h>
+#include <tf2/LinearMath/Quaternion.h>
 #endif
 
 // Use (void) to silent unused warnings.

--- a/src/tf_visual_tools.cpp
+++ b/src/tf_visual_tools.cpp
@@ -34,12 +34,11 @@
 #include <rclcpp/create_timer.hpp>
 #if __has_include(<tf2_eigen/tf2_eigen.hpp>)
 #include <tf2_eigen/tf2_eigen.hpp>
+#include <tf2/convert.hpp>
 #else
 #include <tf2_eigen/tf2_eigen.h>
-#endif
-
-// TF
 #include <tf2/convert.h>
+#endif
 
 // C++
 #include <string>


### PR DESCRIPTION
Some additional geometry2 packages had their old .h C headers deprecated.