### PR TITLE
Use tf2 convert.hpp header

### DIFF
--- a/src/rviz_visual_tools.cpp
+++ b/src/rviz_visual_tools.cpp
@@ -41,7 +41,7 @@
 // Conversions
 #include <tf2_eigen/tf2_eigen.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
-#include <tf2/convert.h>
+#include <tf2/convert.hpp>
 
 // C++
 #include <chrono>


### PR DESCRIPTION
This is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: `patch/ros-rolling-rviz-visual-tools.patch`, authored by Daisuke Nishimatsu.

This updates the remaining tf2 conversion include to the current `.hpp` header. The RoboStack patch also carries CMake target-link modernization, but this PR keeps the header compatibility fix separate and small.
