### PR TITLE
[ROS-O] drop long-empty boost system component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 find_package(Eigen3 REQUIRED)
-find_package(Boost REQUIRED thread system)
+find_package(Boost REQUIRED thread)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(OGRE_OV OGRE)
 


### PR DESCRIPTION
This started failing with Ubuntu 26.04. The component has been empty for a very long time and finally was dropped from the boost cmake config.