### PR TITLE
CMakeLists: dual-support Qt5 and Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,9 +40,22 @@ find_package(rviz_common REQUIRED)
 find_package(rviz_rendering REQUIRED)
 find_package(rviz_default_plugins REQUIRED)
 
-find_package(Qt5 REQUIRED COMPONENTS Widgets)
+# rviz switched to Qt6 in 15.1.14 (ros2/rviz#1635 merged 2025-12-08 but did not
+# land until that patch release; 15.1.13 and earlier are still Qt5).
+# Gate on rviz's version rather than Qt6 availability -- Ubuntu 24.04 ships both
+# Qt5 and Qt6, and linking a Qt6 build against a Qt5 rviz is an ABI mismatch.
+if(rviz_common_VERSION VERSION_GREATER_EQUAL 15.1.14)
+  find_package(Qt6 REQUIRED COMPONENTS Widgets)
+  set(QT_VERSION_MAJOR 6)
+  # Hint for transitive deps that use find_package(QT NAMES Qt6 Qt5 ...) which
+  # may incorrectly resolve to Qt5 due to CMake's ascending path order
+  set(QT_DIR "${Qt6_DIR}")
+else()
+  find_package(Qt5 REQUIRED COMPONENTS Widgets)
+  set(QT_VERSION_MAJOR 5)
+endif()
 
-## Qt5 boilerplate options from http://doc.qt.io/qt-5/cmake-manual.html
+## Qt boilerplate options from https://doc.qt.io/qt-6/cmake-manual.html
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 
@@ -83,7 +96,7 @@ target_link_libraries(${PROJECT_NAME}_gui PUBLIC
   rviz_rendering::rviz_rendering
   rviz_default_plugins::rviz_default_plugins
   rviz_ogre_vendor::OgreMain
-  Qt5::Widgets
+  Qt${QT_VERSION_MAJOR}::Widgets
 )
 
 # prevent pluginlib from using boost

--- a/package.xml
+++ b/package.xml
@@ -39,11 +39,11 @@
   <depend>std_msgs</depend>
   <depend>trajectory_msgs</depend>
 
-  <build_depend>qtbase5-dev</build_depend>
+  <build_depend>qt-base-dev</build_depend>
   <build_depend>eigen</build_depend>
 
   <build_export_depend>eigen</build_export_depend>
-  <exec_depend>libqt5-widgets</exec_depend>
+  <exec_depend>libqtwidgets</exec_depend>
 
   <!-- Launch files -->
   <exec_depend>ament_index_python</exec_depend>


### PR DESCRIPTION
## Why

On Rolling/Resolute, rviz is built against **Qt6**. `rviz_visual_tools`'s `CMakeLists.txt` calls `find_package(Qt5 REQUIRED COMPONENTS Widgets)` unconditionally, so the two collide and CMake refuses to generate:

```
CMake Error: The INTERFACE_QT_MAJOR_VERSION property of "Qt5::Core" does
not agree with the value of QT_MAJOR_VERSION already determined
CMake Generate step failed.  Build files cannot be regenerated correctly.
```

That's from a real `rolling-testing` run on `ubuntu:resolute` ([#301](https://github.com/PickNikRobotics/rviz_visual_tools/pull/301), job `rolling-testing + ccov`). Everything transitively depending on this package — `moveit_visual_tools`, `moveit_task_constructor_visualization`, `snowbot_operating_system` — is blocked behind it.

> **Correction to an earlier version of this description**, which claimed Resolute had removed Qt5 from the apt indexes. That is **not** true — the same CI run shows `apt-get install qtbase5-dev` succeeding on `ubuntu:resolute` (`qt5-qmake-bin 5.15.18+dfsg-1ubuntu1`). Qt5 is still installable; the problem is purely that it cannot be *mixed* with the Qt6 rviz we link against. The fix is unchanged, but the reasoning matters for reviewers.

This is the last Rolling-compat blocker for this repo. The other pieces an earlier audit flagged — `ament_target_dependencies` migration (#277), `tf2` `.h`→`.hpp` renames (#284), CMake required-version bump (#287) — have all already landed on `ros2`.

## How

Select Qt6 when building against **rviz >= 15.1.14**, otherwise keep Qt5.

That's the release where rviz itself switched: [ros2/rviz#1635](https://github.com/ros2/rviz/pull/1635) "Use qt6 as the default dependency from rosdep" (ahcorde, merged 2025-12-08, [`4784c8cd`](https://github.com/ros2/rviz/commit/4784c8cda3f83f7107de581d90986a6edfd2fc20)) flipped `rviz_common/package.xml` from `qtbase5-dev`/`libqt5-*` to `qt6-base-dev`/`libqt6-*`, and first shipped in the [15.1.14](https://github.com/ros2/rviz/tree/15.1.14) tag on 2025-12-17.

Note the threshold is **15.1.14**, not 15.1 — bisecting upstream `rviz_common/package.xml` shows 15.1.0 through 15.1.13 are still Qt5:

| 15.1.11 | 15.1.12 | 15.1.13 | **15.1.14** |
|---|---|---|---|
| `qtbase5-dev` | `qtbase5-dev` | `qtbase5-dev` | **`qt6-base-dev`** |

### Why gate on rviz's version rather than on Qt6 availability

An availability probe (`find_package(Qt6 QUIET)` → `if(Qt6_FOUND)`) says nothing about which Qt **rviz** was built against. `rviz_visual_tools_gui` links `rviz_common`, `rviz_rendering`, `rviz_default_plugins` and `rviz_ogre_vendor::OgreMain`, so its Qt has to match rviz's.

Ubuntu 24.04 ships both Qt5 and Qt6. On a jazzy or kilted machine that also has `qt6-base-dev` installed, the availability probe doesn't quietly mis-select — it **aborts the configure**, because `rviz_common` (Qt5) has already defined the versionless `Qt::Core` target:

```
CMake Error at Qt6CoreVersionlessTargets.cmake:42 (message):
  Some (but not all) targets in this export set were already defined.
  Targets Defined: Qt::Core
  Targets not yet defined: Qt::CorePrivate
```

`QUIET` does not suppress that — it's a `FATAL_ERROR` inside Qt6's own config, not a not-found condition, so the Qt5 fallback is never reached.

This mirrors the approach in [moveit/moveit2#3707](https://github.com/moveit/moveit2/pull/3707), including the `QT_DIR` hint for transitive deps whose `find_package(QT NAMES Qt6 Qt5 ...)` can mis-resolve to Qt5 under CMake's ascending path order.

## Validation

Probed `osrf/ros:<distro>-desktop` containers, comparing the gate's choice against `objdump -p librviz_common.so`:

| distro | `rviz_common_VERSION` | gate selects | rviz actually links | |
|---|---|---|---|---|
| humble | 11.2.26 | Qt5 | `libQt5Core` | ✅ |
| jazzy | 14.1.22 | Qt5 | `libQt5Core` | ✅ |
| kilted | 15.0.13 | Qt5 | `libQt5Core` | ✅ |
| lyrical | 15.2.4 | **Qt6** | `libQt6Core` | ✅ |
| rolling | 16.0.1 | **Qt6** | `libQt6Core` | ✅ |

Also verified that with `qt6-base-dev` additionally installed on jazzy and kilted, this gate still selects Qt5 and configures cleanly.

## package.xml: versionless Qt rosdep keys

The CMake gate alone is **not sufficient**. `package.xml` hard-coded Qt5 rosdep keys:

```xml
<build_depend>qtbase5-dev</build_depend>
<exec_depend>libqt5-widgets</exec_depend>
```

Those resolve to Qt5 on *every* platform, so on Resolute rosdep installs Qt5 while CMake needs Qt6 — which is precisely how the `INTERFACE_QT_MAJOR_VERSION` collision above arises. (Confirmed in CI: `apt-get install qtbase5-dev` and `libqt5widgets5t64` both succeed on Resolute, then the build fails at generate.)

Switched to the versionless keys, the same move [ros2/rviz#1635](https://github.com/ros2/rviz/pull/1635) made in `rviz_common`'s own `package.xml`. rosdep maps them per-platform:

| key | jammy | noble | `*` (resolute) |
|---|---|---|---|
| `qt-base-dev` | `qtbase5-dev` | `qtbase5-dev` | **`qt6-base-dev`** |
| `libqtwidgets` | `libqt5widgets5` | `libqt5widgets5t64` | **`libqt6widgets6`** |

Which agrees with the CMake gate on all five distros — rosdep installs exactly the Qt that CMake then selects:

| distro | base | rviz | CMake picks | rosdep installs |
|---|---|---|---|---|
| humble | jammy | 11.2 | Qt5 | Qt5 |
| jazzy | noble | 14.1 | Qt5 | Qt5 |
| kilted | noble | 15.0 | Qt5 | Qt5 |
| lyrical | resolute | 15.2 | **Qt6** | **Qt6** |
| rolling | resolute | 16.0 | **Qt6** | **Qt6** |

## Scope

Build metadata only — `CMakeLists.txt` + `package.xml`. No C++ source changes are needed: this package has no `.ui` files (so no `qt5_wrap_ui`) and none of the Qt5-only API patterns moveit2 had to fix — only plain widget includes, `Q_OBJECT`, `QCursor` and `Qt::Key_N` enums, all unchanged in Qt6.

Behavior on humble/jazzy/kilted is unchanged.

## CI caveat

This repo's `ros2` matrix currently reports nothing: it lacks `fail-fast: false`, and its `rolling` + `ROS_REPO: main` job cannot run on Resolute, so it fails in ~60s and cancels every sibling. #301 fixes that. **This PR should be rebased on #301 before merging**, so its Qt change actually gets validated rather than cancelled.

## Related

Overlaps #282 (competing Qt6 PR, 8 files, drops the Qt5 fallback and bumps C++ standard). This PR is intentionally minimal and preserves Qt5 for the distros that still need it; #288 reports #282 still doesn't build Qt6 cleanly. Suggest closing #282 in favor of this, and rebasing the CI-actions bump it carries onto `ros2` separately if still wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)