### PR TITLE
ci: unblock and broaden the ros2 matrix for Rolling/Resolute

### DIFF
--- a/.github/workflows/industrial_ci_action.yaml
+++ b/.github/workflows/industrial_ci_action.yaml
@@ -13,17 +13,40 @@ on:
 jobs:
   industrial_ci:
     strategy:
+      # Without this, one failing job cancels its siblings before they report.
+      # The rolling+main job currently fails at setup on Resolute (see below),
+      # which was silently discarding the humble and rolling-testing results.
+      fail-fast: false
       matrix:
         env:
           - ROS_DISTRO: humble
             ROS_REPO: main
           - ROS_DISTRO: humble
             ROS_REPO: testing
-          - ROS_DISTRO: rolling
+          # jazzy and kilted are both Ubuntu Noble, where Qt5 and Qt6 can be
+          # installed side by side. That is the case the rviz-version Qt gate in
+          # CMakeLists exists for, and until now the only coverage this branch
+          # had was humble (jammy, Qt5) and rolling (resolute, Qt6) -- so the
+          # interesting middle was untested despite being released.
+          - ROS_DISTRO: jazzy
             ROS_REPO: main
-            CCOV: true
+          - ROS_DISTRO: kilted
+            ROS_REPO: main
+          # lyrical is Ubuntu Resolute and is a released distro, so its `main`
+          # repo is populated. This gives us a *blocking* Qt6-on-Resolute job
+          # that should stay green, rather than depending on rolling for it.
+          - ROS_DISTRO: lyrical
+            ROS_REPO: main
+            OS_CODE_NAME: resolute
+          # Rolling's `main` apt repo has no Resolute packages yet, so track
+          # `testing`. Pin OS_CODE_NAME rather than relying on industrial_ci's
+          # default. Non-blocking until the Resolute packages are all released,
+          # matching the policy moveit2 uses for its rolling-resolute job.
           - ROS_DISTRO: rolling
             ROS_REPO: testing
+            OS_CODE_NAME: resolute
+            CCOV: true
+            NONBLOCKING: true
 
     env:
       AFTER_RUN_TARGET_TEST: ${{ matrix.env.CCOV && './.ci.prepare_codecov' || '' }}
@@ -36,6 +59,9 @@ jobs:
 
     name: "${{ matrix.env.ROS_DISTRO }}-${{ matrix.env.ROS_REPO }}${{ matrix.env.CCOV && ' + ccov' || ''}}"
     runs-on: ubuntu-latest
+    # Valid here because this is a step-based job. It would be silently ignored
+    # on a job that calls a reusable workflow via `uses:`.
+    continue-on-error: ${{ matrix.env.NONBLOCKING || false }}
     steps:
       - uses: actions/checkout@v4
       # The target directory cache doesn't include the source directory because


### PR DESCRIPTION
## Why

CI on `ros2` currently reports **nothing** useful. Three problems stack.

### 1. No `fail-fast: false`

The matrix omits it, so it defaults to `true`. The rolling job fails in ~60s (problem 2) and GitHub cancels every sibling before it can finish. From #300, run `30764760558` attempt 3:

| Job | Window | Result |
|---|---|---|
| `rolling-main + ccov` | 20:49:41 → 20:50:45 | **failure** |
| `humble-main` | 20:49:47 → 20:50:51 | cancelled |
| `humble-testing` | 20:49:47 → 20:50:52 | cancelled |
| `rolling-testing` | 20:49:41 → 20:50:52 | cancelled |

Re-running reproduced it exactly. One broken-by-environment job was discarding three jobs' worth of signal.

### 2. `rolling` + `ROS_REPO: main` cannot work on Resolute

Rolling's base OS moved to Ubuntu Resolute, and Rolling's **`main`** apt repo has no Resolute packages yet — the job dies in setup, before CMake:

```
'sudo apt-get install ... ros-rolling-ros-environment' returned with 100
'setup_rosdep' returned with code '100' after 0 min 7 sec
```

Not PR-specific — #297 fails the identical job.

### 3. Three released distros had no CI at all

This repo ships a **single `ros2` branch to five distros** but tested two. `jazzy` (4.1.4-4), `kilted` (4.1.4-4) and `lyrical` (4.1.4-5) are all released from this branch with zero coverage. Unlike moveit2 — which can omit distros from `main` because it maintains per-distro branches — there's no second branch here to pick up the slack.

That gap lands exactly where it hurts for the Qt work: **jazzy and kilted are Ubuntu Noble, the platform where Qt5 and Qt6 can be installed side by side** — precisely what the rviz-version Qt gate in #300 guards against. humble covers jammy/Qt5 and rolling covers resolute/Qt6; the interesting middle was untested.

## How

| distro | base OS | `ROS_REPO` | Qt | blocking |
|---|---|---|---|---|
| humble | jammy | main + testing | Qt5 | ✅ |
| jazzy | noble | main | Qt5 | ✅ |
| kilted | noble | main | Qt5 | ✅ |
| lyrical | **resolute** | main | **Qt6** | ✅ |
| rolling | **resolute** | testing | **Qt6** | ⚠️ non-blocking (+ccov) |

- `fail-fast: false`.
- `rolling` → `ROS_REPO: testing`, with `OS_CODE_NAME: resolute` pinned explicitly rather than relying on industrial_ci's default (that default has changed before).
- `rolling` marked **non-blocking**, matching the policy moveit2 applies to its own rolling-resolute job (*"non-blocking until all Resolute packages are released"*). CCOV rides on this job, so coverage is non-blocking too.
- Added `jazzy`, `kilted`, `lyrical`.

`lyrical` is Resolute **and** released, so its `main` repo is populated. That gives a *blocking* Qt6-on-Resolute job that should stay green, instead of leaving all Qt6 coverage on the non-blocking rolling job.

`continue-on-error` is placed on the job, which is valid here because this is a step-based job — it would be [silently ignored](https://docs.github.com/en/actions/using-workflows/reusing-workflows#supported-keywords-for-jobs-that-call-a-reusable-workflow) on a job that calls a reusable workflow via `uses:`.

**Restore the `rolling` + `main` entry, and drop the `NONBLOCKING` flag, once Rolling publishes to `main` for Resolute.**

## Expected result

`humble-*`, `jazzy`, `kilted` and `lyrical` should all report. The `rolling` job may stay red during the transition without blocking.

Note the new `jazzy`/`kilted`/`lyrical` jobs build the **current `ros2` branch**, which still has the unconditional `find_package(Qt5)`. On lyrical (Resolute/Qt6) that is expected to fail with:

```
CMake Error: The INTERFACE_QT_MAJOR_VERSION property of "Qt5::Core" does
not agree with the value of QT_MAJOR_VERSION already determined
```

That is the bug #300 fixes — this PR makes it *visible* rather than cancelled. Merge order: **this PR first, then rebase #300 on top** so its Qt change is finally validated against real jazzy/kilted/lyrical jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)