### PR TITLE
tf_visual_tools: pass Node by reference to TransformBroadcaster

### DIFF
--- a/src/tf_visual_tools.cpp
+++ b/src/tf_visual_tools.cpp
@@ -59,7 +59,7 @@ TFVisualTools::TFVisualTools(const rclcpp::Node::SharedPtr& node, double loop_hz
                            update_period, std::bind(&TFVisualTools::publishAllTransforms, this));
   // , std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 
-  tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(node);
+  tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(*node);
 
   RCLCPP_INFO(logger_, "TFVisualTools Ready.");
 }


### PR DESCRIPTION
## Why

`rolling-testing` fails to compile on Resolute:

```
/opt/ros/rolling/include/rclcpp/rclcpp/node_interfaces/node_topics_interface.hpp:99:1:
error: 'const class std::shared_ptr<rclcpp::Node>' has no member named 'get_node_topics_interface'
   99 | RCLCPP_NODE_INTERFACE_HELPERS_SUPPORT(rclcpp::node_interfaces::NodeTopicsInterface, topics)
```

### Upstream cause

**[ros2/geometry2#940 — "Removed deprecated code"](https://github.com/ros2/geometry2/pull/940)** (ahcorde, merged **2026-07-01**, `+0/-978` across 13 files).

`tf2_ros::TransformBroadcaster` used to accept a node **pointer** via constructor overloads marked:

```cpp
template<class NodeT, class AllocatorT = std::allocator<void>,
  std::enable_if_t<rcpputils::is_pointer<NodeT>::value, bool> = true>
[[deprecated("Use rclcpp::node_interfaces::NodeInterfaces instead of NodeT")]]
explicit TransformBroadcaster(NodeT && node)
```

#940 deleted them. What remains takes `rclcpp::node_interfaces::NodeInterfaces<NodeParametersInterface, NodeTopicsInterface>`, and that template calls `get_node_*_interface()` directly on whatever it's handed — so a `std::shared_ptr<rclcpp::Node>` no longer satisfies it. The error surfaces inside the rclcpp headers, but the change is in geometry2.

`src/tf_visual_tools.cpp:62` passes the `SharedPtr`.

First shipped in **tf2_ros 0.46.2**:

| tf2_ros | pointer ctor | old form |
|---|---|---|
| 0.46.1 | present | ✅ compiles |
| **0.46.2** | **removed by #940** | ❌ fails |
| 0.46.3 | removed | ❌ fails |

## How

Dereference it — which is exactly the migration the deprecation notice asked for.

```diff
-  tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(node);
+  tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(*node);
```

The remaining constructor is templated on node type and accepts a node reference on every supported distro, so **no version guard is needed**.

## Verification

Compiled both forms against each distro's real headers:

| distro | packages from | tf2_ros | `(node)` | `(*node)` |
|---|---|---|---|---|
| humble | `osrf/ros:humble-desktop` | — | ✅ | ✅ |
| jazzy | `osrf/ros:jazzy-desktop` | — | ✅ | ✅ |
| rolling | `osrf/ros:rolling-desktop` | 0.46.1 | ✅ | ✅ |
| rolling | **ros-testing on `ubuntu:resolute`** | 0.46.3 | ❌ **reproduces** | ✅ |

⚠️ Worth noting for anyone reproducing: the prebuilt `osrf/ros:rolling-desktop` image still ships **tf2_ros 0.46.1** and therefore still accepts the old form. Only the current `ros-testing` packages on Resolute reject it — which is what CI and the buildfarm use. Testing against the desktop image alone gives a false pass.

## How it surfaced

The `ros2` matrix used to cancel this job: no `fail-fast: false`, and the `rolling` + `ROS_REPO: main` job died in setup within ~60s, taking its siblings with it. #301 fixed that; #300 fixed the Qt5/Qt6 collision that was masking this behind an earlier CMake generate failure. With both cleared, the build gets 44s into compiling and hits this.

Independent of #300 — this touches only `src/tf_visual_tools.cpp`, that one touches `CMakeLists.txt` + `package.xml`. Either merge order works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)